### PR TITLE
Updated tool to read/write from AWS profile configurations.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,12 +61,47 @@ can build with:
 Usage
 -----
 
+```
+$ aws-google-auth --help
+usage: aws-google-auth [-h] [-v] [-u USERNAME] [-I IDP_ID] [-S SP_ID]
+                       [-R REGION] [-d DURATION] [-p PROFILE]
+
+Acquire temporary AWS credentials via Google SSO
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --version         show program's version number and exit
+
+  -u USERNAME, --username USERNAME
+                        Google Apps username ($GOOGLE_USERNAME)
+  -I IDP_ID, --idp-id IDP_ID
+                        Google SSO IDP identifier ($GOOGLE_IDP_ID)
+  -S SP_ID, --sp-id SP_ID
+                        Google SSO SP identifier ($GOOGLE_SP_ID)
+  -R REGION, --region REGION
+                        AWS region endpoint ($AWS_DEFAULT_REGION)
+  -d DURATION, --duration DURATION
+                        Credential duration ($DURATION)
+  -p PROFILE, --profile PROFILE
+                        AWS profile ($AWS_PROFILE)
+```
+
+Native Python
+~~~~~~~~~~~~~
+
+1. Execute ``aws-google-auth``
+2. You will be prompted to supply each parameter
+
+*Note* You can skip prompts by either passing parameters to the command, or setting the specified Environment variables.
+
+Via Docker
+~~~~~~~~~~~~~
+
 1. Set environment variables for ``GOOGLE_USERNAME``, ``GOOGLE_IDP_ID``,
    and ``GOOGLE_SP_ID`` (see above under "Important Data" for how to
    find the last two; the first one is usually your email address)
 2. For Docker:
    ``docker run -it -e GOOGLE_USERNAME -e GOOGLE_IDP_ID -e GOOGLE_SP_ID aws-google-auth``
-3. For Python: ``aws-google-auth``
 
 You'll be prompted for your password. If you've set up an MFA token for
 your Google account, you'll also be prompted for the current token
@@ -75,6 +110,19 @@ value.
 If you have more than one role available to you, you'll be prompted to
 choose the role from a list; otherwise, if your credentials are correct,
 you'll just see the AWS keys printed on stdout.
+
+
+Storage of profile credentials
+------------------------------
+
+Through the use of AWS profiles, using the `-p` or `--profile` flag, the `aws-google-auth` utility will store the supplied username, IDP and SP details in your `./aws/config` files.
+
+When re-authenticating using the same profile, the values will be remembered to speed up the re-authentication process.
+This enables an approach that enables you to enter your username, IPD and SP values once and then after only need to re-enter your password (and MFA if enabled).
+
+Creating an alias as below can be a quick and easy way to re-authenticate with a simple command shortcut.
+
+`alias aws-development='unset AWS_PROFILE; aws-google-auth -p aws-dev; export AWS_PROFILE=aws-dev'`
 
 
 Notes on Authentication

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ you'll just see the AWS keys printed on stdout.
 Storage of profile credentials
 ------------------------------
 
-Through the use of AWS profiles, using the ``-p` or ``--profile`` flag, the ``aws-google-auth`` utility will store the supplied username, IDP and SP details in your ``./aws/config`` files.
+Through the use of AWS profiles, using the ``-p`` or ``--profile`` flag, the ``aws-google-auth`` utility will store the supplied username, IDP and SP details in your ``./aws/config`` files.
 
 When re-authenticating using the same profile, the values will be remembered to speed up the re-authentication process.
 This enables an approach that enables you to enter your username, IPD and SP values once and then after only need to re-enter your password (and MFA if enabled).

--- a/README.rst
+++ b/README.rst
@@ -61,30 +61,30 @@ can build with:
 Usage
 -----
 
-```
-$ aws-google-auth --help
-usage: aws-google-auth [-h] [-v] [-u USERNAME] [-I IDP_ID] [-S SP_ID]
-                       [-R REGION] [-d DURATION] [-p PROFILE]
+.. code:: shell
+    $ aws-google-auth --help
+    usage: aws-google-auth [-h] [-v] [-u USERNAME] [-I IDP_ID] [-S SP_ID]
+                           [-R REGION] [-d DURATION] [-p PROFILE]
 
-Acquire temporary AWS credentials via Google SSO
+    Acquire temporary AWS credentials via Google SSO
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -v, --version         show program's version number and exit
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v, --version         show program's version number and exit
 
-  -u USERNAME, --username USERNAME
-                        Google Apps username ($GOOGLE_USERNAME)
-  -I IDP_ID, --idp-id IDP_ID
-                        Google SSO IDP identifier ($GOOGLE_IDP_ID)
-  -S SP_ID, --sp-id SP_ID
-                        Google SSO SP identifier ($GOOGLE_SP_ID)
-  -R REGION, --region REGION
-                        AWS region endpoint ($AWS_DEFAULT_REGION)
-  -d DURATION, --duration DURATION
-                        Credential duration ($DURATION)
-  -p PROFILE, --profile PROFILE
-                        AWS profile ($AWS_PROFILE)
-```
+      -u USERNAME, --username USERNAME
+                            Google Apps username ($GOOGLE_USERNAME)
+      -I IDP_ID, --idp-id IDP_ID
+                            Google SSO IDP identifier ($GOOGLE_IDP_ID)
+      -S SP_ID, --sp-id SP_ID
+                            Google SSO SP identifier ($GOOGLE_SP_ID)
+      -R REGION, --region REGION
+                            AWS region endpoint ($AWS_DEFAULT_REGION)
+      -d DURATION, --duration DURATION
+                            Credential duration ($DURATION)
+      -p PROFILE, --profile PROFILE
+                            AWS profile ($AWS_PROFILE)
+
 
 Native Python
 ~~~~~~~~~~~~~
@@ -115,14 +115,14 @@ you'll just see the AWS keys printed on stdout.
 Storage of profile credentials
 ------------------------------
 
-Through the use of AWS profiles, using the `-p` or `--profile` flag, the `aws-google-auth` utility will store the supplied username, IDP and SP details in your `./aws/config` files.
+Through the use of AWS profiles, using the ``-p` or ```--profile`` flag, the ``aws-google-auth` utility will store the supplied username, IDP and SP details in your ```./aws/config`` files.
 
 When re-authenticating using the same profile, the values will be remembered to speed up the re-authentication process.
 This enables an approach that enables you to enter your username, IPD and SP values once and then after only need to re-enter your password (and MFA if enabled).
 
 Creating an alias as below can be a quick and easy way to re-authenticate with a simple command shortcut.
 
-`alias aws-development='unset AWS_PROFILE; aws-google-auth -p aws-dev; export AWS_PROFILE=aws-dev'`
+``alias aws-development='unset AWS_PROFILE; aws-google-auth -p aws-dev; export AWS_PROFILE=aws-dev'``
 
 
 Notes on Authentication

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ you'll just see the AWS keys printed on stdout.
 Storage of profile credentials
 ------------------------------
 
-Through the use of AWS profiles, using the ``-p` or ```--profile`` flag, the ``aws-google-auth`` utility will store the supplied username, IDP and SP details in your ```./aws/config`` files.
+Through the use of AWS profiles, using the ``-p` or ``--profile`` flag, the ``aws-google-auth`` utility will store the supplied username, IDP and SP details in your ``./aws/config`` files.
 
 When re-authenticating using the same profile, the values will be remembered to speed up the re-authentication process.
 This enables an approach that enables you to enter your username, IPD and SP values once and then after only need to re-enter your password (and MFA if enabled).

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ Usage
 -----
 
 .. code:: shell
+
     $ aws-google-auth --help
     usage: aws-google-auth [-h] [-v] [-u USERNAME] [-I IDP_ID] [-S SP_ID]
                            [-R REGION] [-d DURATION] [-p PROFILE]
@@ -115,7 +116,7 @@ you'll just see the AWS keys printed on stdout.
 Storage of profile credentials
 ------------------------------
 
-Through the use of AWS profiles, using the ``-p` or ```--profile`` flag, the ``aws-google-auth` utility will store the supplied username, IDP and SP details in your ```./aws/config`` files.
+Through the use of AWS profiles, using the ``-p` or ```--profile`` flag, the ``aws-google-auth`` utility will store the supplied username, IDP and SP details in your ```./aws/config`` files.
 
 When re-authenticating using the same profile, the values will be remembered to speed up the re-authentication process.
 This enables an approach that enables you to enter your username, IPD and SP values once and then after only need to re-enter your password (and MFA if enabled).

--- a/README.rst
+++ b/README.rst
@@ -76,9 +76,6 @@ If you have more than one role available to you, you'll be prompted to
 choose the role from a list; otherwise, if your credentials are correct,
 you'll just see the AWS keys printed on stdout.
 
-You should ``eval`` the ``export`` statements that come out, because
-that'll set environment variables for you. This tools currently doesn't
-write credentials to an ``~/.aws/credentials`` file
 
 Notes on Authentication
 -----------------------
@@ -120,3 +117,6 @@ Acknowledgements
 This work is inspired by `keyme <https://github.com/wheniwork/keyme>`__
 -- their digging into the guts of how Google SAML auth works is what's
 enabled it.
+
+The attribute management and credential injection into AWS configuration files
+was heavily borrowed from `aws-adfs <https://github.com/venth/aws-adfs>`

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -14,8 +14,6 @@ from lxml import etree
 import configparser
 
 import prepare
-# from . import prepare
-# from .prepare import google_config
 
 VERSION = "0.0.6"
 

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -11,6 +11,11 @@ import time
 import json
 from bs4 import BeautifulSoup
 from lxml import etree
+import configparser
+
+import prepare
+# from . import prepare
+# from .prepare import google_config
 
 VERSION = "0.0.6"
 
@@ -19,6 +24,7 @@ IDP_ID = os.getenv("GOOGLE_IDP_ID")
 SP_ID = os.getenv("GOOGLE_SP_ID")
 USERNAME = os.getenv("GOOGLE_USERNAME")
 DURATION = os.getenv("DURATION")
+PROFILE = os.getenv("AWS_PROFILE")
 
 class GoogleAuth:
     def __init__(self, **kwargs):
@@ -277,32 +283,41 @@ def cli():
     parser.add_argument('-S', '--sp-id', default=SP_ID, help='Google SSO SP identifier ($GOOGLE_SP_ID)')
     parser.add_argument('-R', '--region', default=REGION, help='AWS region endpoint ($AWS_DEFAULT_REGION)')
     parser.add_argument('-d', '--duration', default=DURATION, help='Credential duration ($DURATION)')
+    parser.add_argument('-p', '--profile', default=PROFILE, help='AWS profile ($AWS_PROFILE)')
 
     args = parser.parse_args()
-
-    if args.username is None:
-        args.username = raw_input("Google username: ")
-
-    if args.idp_id is None or args.sp_id is None:
-        print "Must set both GOOGLE_IDP_ID and GOOGLE_SP_ID"
-        parser.print_help()
-        sys.exit(1)
-
-    if args.duration is None:
-        print "Setting duration to 3600 seconds"
-        args.duration = 3600
 
     if args.duration > 3600:
         print "Duration must be less than or equal to 3600"
         duration = 3600
 
+    config = prepare.get_prepared_config(
+        args.profile,
+        args.region,
+        args.username,
+        args.idp_id,
+        args.sp_id,
+        args.duration
+    )
+
+    if config.google_username is None:
+        config.google_username = raw_input("Google username: ")
+    else:
+        print "Google username: " + config.google_username
+
+    if config.google_idp_id is None:
+        config.google_idp_id = raw_input("Google idp: ")
+
+    if config.google_sp_id is None:
+        config.google_sp_id = raw_input("Google sp: ")
+
     passwd = getpass.getpass()
 
     google = GoogleAuth(
-        username=args.username,
+        username=config.google_username,
         password=passwd,
-        idp_id=args.idp_id,
-        sp_id=args.sp_id
+        idp_id=config.google_idp_id,
+        sp_id=config.google_sp_id
     )
 
     google.do_login()
@@ -312,18 +327,63 @@ def cli():
     doc = etree.fromstring(base64.b64decode(encoded_saml))
     roles = dict([x.split(',') for x in doc.xpath('//*[@Name = "https://aws.amazon.com/SAML/Attributes/Role"]//text()')])
 
-    role, provider = pick_one(roles)
+    if not config.role_arn in roles:
+        config.role_arn, config.provider = pick_one(roles)
 
-    print "Assuming " + role
+    print "Assuming " + config.role_arn
 
-    sts = boto3.client('sts', region_name=REGION)
+    sts = boto3.client('sts', region_name=config.region)
     token = sts.assume_role_with_saml(
-                RoleArn=role,
-                PrincipalArn=provider,
+                RoleArn=config.role_arn,
+                PrincipalArn=config.provider,
                 SAMLAssertion=encoded_saml,
-                DurationSeconds=args.duration)
+                DurationSeconds=config.duration)
 
-    print "export AWS_ACCESS_KEY_ID='{}'".format(token['Credentials']['AccessKeyId'])
-    print "export AWS_SECRET_ACCESS_KEY='{}'".format(token['Credentials']['SecretAccessKey'])
-    print "export AWS_SESSION_TOKEN='{}'".format(token['Credentials']['SessionToken'])
-    print "export AWS_SESSION_EXPIRATION='{}'".format(token['Credentials']['Expiration'])
+    _store(config, token)
+
+
+def _store(config, aws_session_token):
+
+    def store_config(profile, config_location, storer):
+        config_file = configparser.RawConfigParser()
+        config_file.read(config_location)
+
+        if not config_file.has_section(profile):
+            config_file.add_section(profile)
+
+        storer(config_file, profile)
+
+        with open(config_location, 'w+') as f:
+            try:
+                config_file.write(f)
+            finally:
+                f.close()
+
+    def credentials_storer(config_file, profile):
+        config_file.set(profile, 'aws_access_key_id', aws_session_token['Credentials']['AccessKeyId'])
+        config_file.set(profile, 'aws_secret_access_key', aws_session_token['Credentials']['SecretAccessKey'])
+        config_file.set(profile, 'aws_session_token', aws_session_token['Credentials']['SessionToken'])
+        config_file.set(profile, 'aws_security_token', aws_session_token['Credentials']['SessionToken'])
+
+    def config_storer(config_file, profile):
+        config_file.set(profile, 'region', config.region)
+        config_file.set(profile, 'output', config.output_format)
+        config_file.set(profile, 'google_config.role_arn', config.role_arn)
+        config_file.set(profile, 'google_config.provider', config.provider)
+        config_file.set(profile, 'google_config.google_idp_id', config.google_idp_id)
+        config_file.set(profile, 'google_config.google_sp_id', config.google_sp_id)
+        config_file.set(profile, 'google_config.google_username', config.google_username)
+        config_file.set(profile, 'google_config.duration', config.duration)
+
+    store_config(config.profile, config.aws_credentials_location, credentials_storer)
+    if config.profile == 'default':
+        store_config(config.profile, config.aws_config_location, config_storer)
+    else:
+        store_config('profile {}'.format(config.profile), config.aws_config_location, config_storer)
+
+
+if __name__ == '__main__':
+    try:
+        cli()
+    except KeyboardInterrupt:
+        pass

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -15,7 +15,7 @@ import configparser
 
 import prepare
 
-VERSION = "0.0.6"
+VERSION = "0.0.7"
 
 REGION = os.getenv("AWS_DEFAULT_REGION") or "ap-southeast-2"
 IDP_ID = os.getenv("GOOGLE_IDP_ID")
@@ -336,6 +336,12 @@ def cli():
                 PrincipalArn=config.provider,
                 SAMLAssertion=encoded_saml,
                 DurationSeconds=config.duration)
+
+    if conifig.profile is None:
+        print "export AWS_ACCESS_KEY_ID='{}'".format(token['Credentials']['AccessKeyId'])
+        print "export AWS_SECRET_ACCESS_KEY='{}'".format(token['Credentials']['SecretAccessKey'])
+        print "export AWS_SESSION_TOKEN='{}'".format(token['Credentials']['SessionToken'])
+        print "export AWS_SESSION_EXPIRATION='{}'".format(token['Credentials']['Expiration'])
 
     _store(config, token)
 

--- a/aws_google_auth/prepare.py
+++ b/aws_google_auth/prepare.py
@@ -53,10 +53,6 @@ def _create_google_default_config():
     config.aws_credentials_location = os.path.expanduser(session.get_config_variable('credentials_file'))
     config.aws_config_location = os.path.expanduser(session.get_config_variable('config_file'))
 
-    # SSL certificate verification: Whether or not strict certificate
-    # verification is done, False should only be used for dev/test
-    config.ssl_verification = True
-
     config.role_arn = None
     config.provider = None
 
@@ -64,10 +60,6 @@ def _create_google_default_config():
     config.google_idp_id = None
     config.google_username = None
     config.duration = 3600
-
-    # Note: if your bucket require CORS, it is advised that you use path style addressing
-    # (which is set by default in signature version 4).
-    config.s3_signature_version = None
 
     return config
 
@@ -91,27 +83,12 @@ def _load_google_config_from_stored_profile(google_config, profile):
     def load_config(config, profile):
         google_config.region = config.get_or(profile, 'region', google_config.region)
         google_config.output_format = config.get_or(profile, 'output', google_config.output_format)
-        google_config.ssl_verification = ast.literal_eval(config.get_or(
-            profile, 'google_config.ssl_verification',
-            str(google_config.ssl_verification)))
 
         google_config.role_arn = config.get_or(profile, 'google_config.role_arn', google_config.role_arn)
         google_config.provider = config.get_or(profile, 'google_config.provider', google_config.provider)
         google_config.google_idp_id = config.get_or(profile, 'google_config.google_idp_id', google_config.google_idp_id)
         google_config.google_sp_id = config.get_or(profile, 'google_config.google_sp_id', google_config.google_sp_id)
         google_config.google_username = config.get_or(profile, 'google_config.google_username', google_config.google_username)
-
-        google_config.s3_signature_version = None
-        rawS3SubSection = config.get_or(profile, 's3', None)
-        if rawS3SubSection:
-            s3SubSection = configparser.RawConfigParser()
-            setattr(s3SubSection, get_or.__name__, MethodType(get_or, s3SubSection))
-            s3SubSection.read_string('[s3_section]\n' + rawS3SubSection)
-            google_config.s3_signature_version = s3SubSection.get_or(
-                's3_section',
-                'signature_version',
-                google_config.s3_signature_version
-            )
 
     if profile == 'default':
         load_from_config(google_config.aws_config_location, profile, load_config)

--- a/aws_google_auth/prepare.py
+++ b/aws_google_auth/prepare.py
@@ -1,0 +1,148 @@
+import ast
+import configparser
+import os
+import botocore.session
+from types import MethodType
+
+
+def get_prepared_config(
+        profile,
+        region,
+        google_username,
+        google_idp_id,
+        google_sp_id,
+        duration
+):
+
+    def default_if_none(value, default):
+        return value if value is not None else default
+
+    google_config.profile = default_if_none(profile, google_config.profile)
+
+    _create_base_aws_cli_config_files_if_needed(google_config)
+    _load_google_config_from_stored_profile(google_config, google_config.profile)
+
+    google_config.region = default_if_none(region, google_config.region)
+    google_config.google_username = default_if_none(google_username, google_config.google_username)
+    google_config.google_idp_id = default_if_none(google_idp_id, google_config.google_idp_id)
+    google_config.google_sp_id = default_if_none(google_sp_id, google_config.google_sp_id)
+    google_config.duration = default_if_none(duration, google_config.duration)
+
+    return google_config
+
+
+def _create_google_default_config():
+    config = type('', (), {})()
+
+    # Use botocore session API to get defaults
+    session = botocore.session.Session()
+
+    # region: The default AWS region that this script will connect
+    # to for all API calls
+    config.region = session.get_config_variable('region') or 'eu-central-1'
+
+    # aws cli profile to store config and access keys into
+    config.profile = session.profile or 'default'
+
+    # output format: The AWS CLI output format that will be configured in the
+    # adf profile (affects subsequent CLI calls)
+    config.output_format = session.get_config_variable('format') or 'json'
+
+    # aws credential location: The file where this script will store the temp
+    # credentials under the configured profile
+    config.aws_credentials_location = os.path.expanduser(session.get_config_variable('credentials_file'))
+    config.aws_config_location = os.path.expanduser(session.get_config_variable('config_file'))
+
+    # SSL certificate verification: Whether or not strict certificate
+    # verification is done, False should only be used for dev/test
+    config.ssl_verification = True
+
+    config.role_arn = None
+    config.provider = None
+
+    config.google_sp_id = None
+    config.google_idp_id = None
+    config.google_username = None
+    config.duration = 3600
+
+    # Note: if your bucket require CORS, it is advised that you use path style addressing
+    # (which is set by default in signature version 4).
+    config.s3_signature_version = None
+
+    return config
+
+
+def _load_google_config_from_stored_profile(google_config, profile):
+
+    def get_or(self, profile, option, default_value):
+        if self.has_option(profile, option):
+            return self.get(profile, option)
+        return default_value
+
+    def load_from_config(config_location, profile, loader):
+        config = configparser.RawConfigParser()
+        config.read(config_location)
+        if config.has_section(profile):
+            setattr(config, get_or.__name__, MethodType(get_or, config))
+            loader(config, profile)
+
+        del config
+
+    def load_config(config, profile):
+        google_config.region = config.get_or(profile, 'region', google_config.region)
+        google_config.output_format = config.get_or(profile, 'output', google_config.output_format)
+        google_config.ssl_verification = ast.literal_eval(config.get_or(
+            profile, 'google_config.ssl_verification',
+            str(google_config.ssl_verification)))
+
+        google_config.role_arn = config.get_or(profile, 'google_config.role_arn', google_config.role_arn)
+        google_config.provider = config.get_or(profile, 'google_config.provider', google_config.provider)
+        google_config.google_idp_id = config.get_or(profile, 'google_config.google_idp_id', google_config.google_idp_id)
+        google_config.google_sp_id = config.get_or(profile, 'google_config.google_sp_id', google_config.google_sp_id)
+        google_config.google_username = config.get_or(profile, 'google_config.google_username', google_config.google_username)
+
+        google_config.s3_signature_version = None
+        rawS3SubSection = config.get_or(profile, 's3', None)
+        if rawS3SubSection:
+            s3SubSection = configparser.RawConfigParser()
+            setattr(s3SubSection, get_or.__name__, MethodType(get_or, s3SubSection))
+            s3SubSection.read_string('[s3_section]\n' + rawS3SubSection)
+            google_config.s3_signature_version = s3SubSection.get_or(
+                's3_section',
+                'signature_version',
+                google_config.s3_signature_version
+            )
+
+    if profile == 'default':
+        load_from_config(google_config.aws_config_location, profile, load_config)
+    else:
+        load_from_config(google_config.aws_config_location, 'profile ' + profile, load_config)
+
+
+def _create_base_aws_cli_config_files_if_needed(google_config):
+    def touch(fname, mode=0o600):
+        flags = os.O_CREAT | os.O_APPEND
+        with os.fdopen(os.open(fname, flags, mode)) as f:
+            try:
+                os.utime(fname, None)
+            finally:
+                f.close()
+
+    aws_config_root = os.path.dirname(google_config.aws_config_location)
+
+    if not os.path.exists(aws_config_root):
+        os.mkdir(aws_config_root, 0o700)
+
+    if not os.path.exists(google_config.aws_credentials_location):
+        touch(google_config.aws_credentials_location)
+
+    aws_credentials_root = os.path.dirname(google_config.aws_credentials_location)
+
+    if not os.path.exists(aws_credentials_root):
+        os.mkdir(aws_credentials_root, 0o700)
+
+    if not os.path.exists(google_config.aws_config_location):
+        touch(google_config.aws_config_location)
+
+
+google_config = _create_google_default_config()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-VERSION = '0.0.6'
+VERSION = '0.0.7'
 
 setup(
     name='aws-google-auth',

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     # install_requires=['peppercorn'],
-    install_requires=['boto3', 'lxml', 'requests', 'beautifulsoup4'],
+    install_requires=['boto3', 'lxml', 'requests', 'beautifulsoup4', 'configparser'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
@@ -114,4 +114,3 @@ setup(
         ],
     },
 )
-


### PR DESCRIPTION
This PR resolves #5 by storing details in a profile in `credentials` and `config`.

 ```
$ aws-google-auth -p cevo-demo
Google username: email.address@goes.here
Google idp: abcdef
Google sp: 12345
Password: 
[  1] arn:aws:iam::54321342:role/Dev-Administrator
[  2] arn:aws:iam::12345678:role/Demo-Administrator
[  3] arn:aws:iam::98765432:role/Prod-Administrator
Type the number (1 - 3) of the role to assume: 2
Assuming arn:aws:iam::12345678:role/Demo-Administrator
```

That then results in:

```
[profile cevo-demo]
region = ap-southeast-2
output = json
google_config.role_arn = arn:aws:iam::12345678:role/Demo-Administrator
google_config.provider = arn:aws:iam::12345678:saml-provider/GoogleApps
google_config.google_idp_id = abcdef
google_config.google_sp_id = 12345
google_config.google_username = email.address@goes.here
google_config.duration = 3600
```

So when you run `aws-google-auth -p cevo-demo` again it auto-fills it all and looks like:

```
$ aws-google-auth -p cevo-demo
Google username: email.address@goes.here
Password: 
Assuming arn:aws:iam::12345678:role/Demo-Administrator
```

With much thanks to https://github.com/venth/aws-adfs for inspiration and chunks of code.