### PR TITLE
Re-pick the role

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -312,8 +312,8 @@ def cli():
                         help='Credential duration ($DURATION)')
     parser.add_argument('-p', '--profile', default=PROFILE,
                         help='AWS profile ($AWS_PROFILE)')
-    parser.add_argument('-a', '--ask-role', default=ASK_ROLE, 
-                        help='Set true to always pick the role')
+    parser.add_argument('-a', '--ask-role', default=ASK_ROLE,
+                        ,action='store_true', help='Set true to always pick the role')
     parser.add_argument('-V', '--version', action='version',
                         version='%(prog)s {version}'.format(version=_version.__version__))
 

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -313,7 +313,7 @@ def cli():
     parser.add_argument('-p', '--profile', default=PROFILE,
                         help='AWS profile ($AWS_PROFILE)')
     parser.add_argument('-a', '--ask-role', default=ASK_ROLE,
-                        ,action='store_true', help='Set true to always pick the role')
+                        action='store_true', help='Set true to always pick the role')
     parser.add_argument('-V', '--version', action='version',
                         version='%(prog)s {version}'.format(version=_version.__version__))
 

--- a/aws_google_auth/prepare.py
+++ b/aws_google_auth/prepare.py
@@ -11,7 +11,8 @@ def get_prepared_config(
         google_username,
         google_idp_id,
         google_sp_id,
-        duration
+        duration,
+        ask_role
 ):
 
     def default_if_none(value, default):
@@ -28,6 +29,7 @@ def get_prepared_config(
     google_config.google_idp_id = default_if_none(google_idp_id, google_config.google_idp_id)
     google_config.google_sp_id = default_if_none(google_sp_id, google_config.google_sp_id)
     google_config.duration = default_if_none(duration, google_config.duration)
+    google_config.ask_role = default_if_none(ask_role, False)
 
     return google_config
 

--- a/aws_google_auth/prepare.py
+++ b/aws_google_auth/prepare.py
@@ -29,7 +29,7 @@ def get_prepared_config(
     google_config.google_idp_id = default_if_none(google_idp_id, google_config.google_idp_id)
     google_config.google_sp_id = default_if_none(google_sp_id, google_config.google_sp_id)
     google_config.duration = default_if_none(duration, google_config.duration)
-    google_config.ask_role = default_if_none(ask_role, False)
+    google_config.ask_role = default_if_none(ask_role, google_config.ask_role)
 
     return google_config
 
@@ -63,6 +63,7 @@ def _create_google_default_config():
     config.google_idp_id = None
     config.google_username = None
     config.duration = 3600
+    config.ask_role = False
 
     return config
 


### PR DESCRIPTION
Hi, we had a daily flow when I use the same profile and switch it between roles/accounts.
Currently, I don't have an option to do it, that is why I compiled for us a custom version.

Not sure if you'd like to merge it as it is. If not, could you add an option to force the user to pick up a role again if I had the role from the previous run?
Thanks.