### PR TITLE
Add information about session expire

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -12,6 +12,7 @@ import json
 from bs4 import BeautifulSoup
 from lxml import etree
 import configparser
+from tzlocal import get_localzone
 
 from . import _version
 from . import prepare
@@ -381,6 +382,7 @@ def cli():
                 SAMLAssertion=encoded_saml,
                 DurationSeconds=config.duration)
 
+    print("Credentials Expiration: " + format(token['Credentials']['Expiration'].astimezone(get_localzone())))
     if config.profile is None:
         print_exports(token)
 
@@ -393,7 +395,7 @@ def print_exports(token):
         token['Credentials']['AccessKeyId'],
         token['Credentials']['SecretAccessKey'],
         token['Credentials']['SessionToken'],
-        token['Credentials']['Expiration']
+        token['Credentials']['Expiration'].strftime('%Y-%m-%dT%H:%M:%S%z')
     )
 
     print(formatted)
@@ -420,6 +422,7 @@ def _store(config, aws_session_token):
         config_file.set(profile, 'aws_secret_access_key', aws_session_token['Credentials']['SecretAccessKey'])
         config_file.set(profile, 'aws_session_token', aws_session_token['Credentials']['SessionToken'])
         config_file.set(profile, 'aws_security_token', aws_session_token['Credentials']['SessionToken'])
+        config_file.set(profile, 'aws_session_expiration', aws_session_token['Credentials']['Expiration'].strftime('%Y-%m-%dT%H:%M:%S%z'))
 
     def config_storer(config_file, profile):
         config_file.set(profile, 'region', config.region)

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     # install_requires=['peppercorn'],
-    install_requires=['boto3', 'lxml', 'requests', 'beautifulsoup4', 'configparser'],
+    install_requires=['boto3', 'lxml', 'requests', 'beautifulsoup4', 'configparser', 'tzlocal'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Hi,
There was already such info, only in `print_exports`. But it was in default format when it loses the timezone info. 
So I've added the same info to config and update it to the standard ISO8601. So it could be easily used if need.

In my case it allows me to see the details when I'm running commands in CLI. As some script could take time and I'd like to avoid the problem when session expires in the middle of execution, I update the session each time.
It could be very annoying. And while I hope AWS will allow using us more than 1 hour one day, I did this small change here.
And I can use it in my customized theme in ZSH to see the timer for current AWS session.

Perhaps it could help others. At least it shouldn't break anything anyway.
Thanks