### PR TITLE
Add new CLI option to specify desired Role ARN

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ Usage
     $ aws-google-auth --help
     usage: aws-google-auth [-h] [-v] [-u USERNAME] [-I IDP_ID] [-S SP_ID]
                            [-R REGION] [-d DURATION] [-p PROFILE]
+                           [-r AWS_ROLE_ARN ]
 
     Acquire temporary AWS credentials via Google SSO
 
@@ -102,6 +103,8 @@ Usage
                             AWS profile ($AWS_PROFILE)
       -a ASK_ROLE, --ask-role ASK_ROLE
                             Set true to always pick the role
+      -r AWS_ROLE_ARN, --role-arn AWS_ROLE_ARN
+                            The ARN of the role to assume
 
 
 Native Python

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -32,6 +32,7 @@ MAX_DURATION = 3600
 DURATION = int(os.getenv("DURATION") or MAX_DURATION)
 PROFILE = os.getenv("AWS_PROFILE")
 ASK_ROLE = os.getenv("AWS_ASK_ROLE") or False
+ROLE_ARN = os.getenv("AWS_ROLE_ARN")
 U2F_DISABLED = os.getenv("U2F_DISABLED") or False
 
 
@@ -372,8 +373,10 @@ def cli():
                         help='Credential duration ($DURATION)')
     parser.add_argument('-p', '--profile', default=PROFILE,
                         help='AWS profile ($AWS_PROFILE)')
-    parser.add_argument('-a', '--ask-role', default=ASK_ROLE,
+    role_group = parser.add_mutually_exclusive_group()
+    role_group.add_argument('-a', '--ask-role', default=ASK_ROLE,
                         action='store_true', help='Set true to always pick the role')
+    role_group.add_argument('-r', '--role-arn', help='The ARN of the role to assume')
     parser.add_argument('-V', '--version', action='version',
                         version='%(prog)s {version}'.format(version=_version.__version__))
 
@@ -390,7 +393,8 @@ def cli():
         args.idp_id,
         args.sp_id,
         args.duration,
-        args.ask_role
+        args.ask_role,
+        args.role_arn
     )
 
     if config.google_username is None:
@@ -429,7 +433,9 @@ def cli():
     doc = etree.fromstring(base64.b64decode(encoded_saml))
     roles = parse_roles(doc)
 
-    if config.role_arn not in roles or config.ask_role:
+    if config.role_arn in roles and not config.ask_role:
+        config.provider = roles[config.role_arn]
+    else:
         config.role_arn, config.provider = pick_one(roles)
 
     print("Assuming " + config.role_arn)

--- a/aws_google_auth/prepare.py
+++ b/aws_google_auth/prepare.py
@@ -11,7 +11,8 @@ def get_prepared_config(
         google_idp_id,
         google_sp_id,
         duration,
-        ask_role
+        ask_role,
+        role_arn
 ):
 
     def default_if_none(value, default):
@@ -29,6 +30,7 @@ def get_prepared_config(
     google_config.google_sp_id = default_if_none(google_sp_id, google_config.google_sp_id)
     google_config.duration = default_if_none(duration, google_config.duration)
     google_config.ask_role = default_if_none(ask_role, google_config.ask_role)
+    google_config.role_arn = default_if_none(role_arn, google_config.role_arn)
 
     return google_config
 


### PR DESCRIPTION
This will add a new option to the CLI, ROLE_ARN. Using this new option will allow for the user to specify the role they're looking to assume, preventing the prompt. The "Ask Role" and "Role ARN" options are mutually exclusive.

Sample Usage:
```bash
aws-google-auth -u mide@example.com -I $IDP_ID -S $SP_ID -r arn:aws:iam::123456789876:role/My-Sample-Role
Google username: mide@example.com
Password: 
Touch the flashing U2F device to authenticate...
Assuming arn:aws:iam::123456789876:role/My-Sample-Role
Credentials Expiration: 2017-12-05 15:03:17-05:00
...
```

In this case, I was only prompted to enter my Google password and to touch my U2F device. This is a help when automating. 