### PR TITLE
Fix bug (#22) to prevent AWS configuration corruption

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -444,8 +444,8 @@ def cli():
     print("Credentials Expiration: " + format(token['Credentials']['Expiration'].astimezone(get_localzone())))
     if config.profile is None:
         print_exports(token)
-
-    _store(config, token)
+    else:
+        _store(config, token)
 
 
 def print_exports(token):
@@ -464,6 +464,7 @@ def print_exports(token):
 def _store(config, aws_session_token):
 
     def store_config(profile, config_location, storer):
+        assert (profile is not None), "Can not store config/credentials if the AWS_PROFILE is None."
         config_file = configparser.RawConfigParser()
         config_file.read(config_location)
 

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -442,10 +442,12 @@ def cli():
                 DurationSeconds=config.duration)
 
     print("Credentials Expiration: " + format(token['Credentials']['Expiration'].astimezone(get_localzone())))
-    if config.profile is None:
-        print_exports(token)
-    else:
-        _store(config, token)
+
+    # Set the profile to "default" if none set.
+    config.profile = config.profile or "default"
+
+    print_exports(token)
+    _store(config, token)
 
 
 def print_exports(token):

--- a/aws_google_auth/tests/test_write_config_no_profile.py
+++ b/aws_google_auth/tests/test_write_config_no_profile.py
@@ -1,0 +1,24 @@
+from aws_google_auth import GoogleAuth, _store, prepare
+
+
+# Test that when no AWS_PROFILE (-p) is set that the config writer will raise
+# an AssersionError. It doesn't make sense to write credentials without
+# a profile, so the running of the store function implies the profile is set.
+#
+# See: https://github.com/cevoaustralia/aws-google-auth/issues/22
+def test_write_config_no_profile():
+    try:
+        config = prepare.get_prepared_config(
+            None,               # Profile
+            "aws-region",       # AWS Region
+            "user@example.com", # User
+            "789xyz",           # IDP ID
+            "abc123",           # SP ID
+            60,                 # Credential Duration
+            False               # Ask Role
+        )
+        token = "Some_Token_String"
+        _store(config, token)
+    except AssertionError as e:
+        assert(str(e) == 'Can not store config/credentials if the '
+                         'AWS_PROFILE is None.')


### PR DESCRIPTION
This fixes #22, a bug that caused the AWS credentials to become corrupted by inserting a `[None]` section into the configuration. Since it doesn't make sense to write to a saved profile if one isn't set, it will just export instead.