### PR TITLE
Enables local development without throwing argument errors.

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -380,6 +380,13 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
+def main():
+    try:
+        cli(sys.argv[1:])
+    except KeyboardInterrupt:
+        pass
+
+
 def cli(cli_args):
 
     args = parse_args(args=cli_args)
@@ -508,7 +515,4 @@ def _store(config, aws_session_token):
 
 
 if __name__ == '__main__':
-    try:
-        cli(sys.argv[1:])
-    except KeyboardInterrupt:
-        pass
+    main()

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
         'console_scripts': [
-            'aws-google-auth=aws_google_auth:cli',
+            'aws-google-auth=aws_google_auth:main',
         ],
     },
 


### PR DESCRIPTION
Recent changes prevented local execution of the tool, returning an error of "TypeError: cli() missing 1 required positional argument: 'cli_args'". 

**Note:** I'm installing using `pip -e .[u2f]`.

**Example of Error (in a brand new `virtualenv`):**
```
% aws-google-auth
Traceback (most recent call last):
  File "/Users/mide/Projects/aws-google-auth/bin/aws-google-auth", line 11, in <module>
    load_entry_point('aws-google-auth', 'console_scripts', 'aws-google-auth')()
TypeError: cli() missing 1 required positional argument: 'cli_args'
```