### PR TITLE
Fix bug (#22) to prevent AWS configuration corruption

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Usage
       -d DURATION, --duration DURATION
                             Credential duration ($DURATION)
       -p PROFILE, --profile PROFILE
-                            AWS profile ($AWS_PROFILE)
+                            AWS profile ($AWS_PROFILE) (defaults to 'sts')
       -a ASK_ROLE, --ask-role ASK_ROLE
                             Set true to always pick the role
 

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,8 @@ Usage
       -d DURATION, --duration DURATION
                             Credential duration ($DURATION)
       -p PROFILE, --profile PROFILE
-                            AWS profile ($AWS_PROFILE) (defaults to 'sts')
+                            AWS profile (defaults to value of $AWS_PROFILE,
+                            then falls back to 'sts')
       -a ASK_ROLE, --ask-role ASK_ROLE
                             Set true to always pick the role
 

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -447,9 +447,8 @@ def cli(cli_args):
                 DurationSeconds=config.duration)
 
     print("Credentials Expiration: " + format(token['Credentials']['Expiration'].astimezone(get_localzone())))
-    if config.profile is None:
-        print_exports(token)
 
+    print_exports(token)
     _store(config, token)
 
 
@@ -469,6 +468,7 @@ def print_exports(token):
 def _store(config, aws_session_token):
 
     def store_config(profile, config_location, storer):
+        assert (profile is not None), "Can not store config/credentials if the AWS_PROFILE is None."
         config_file = configparser.RawConfigParser()
         config_file.read(config_location)
 

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -371,7 +371,7 @@ def parse_args(args):
     parser.add_argument('-d', '--duration', type=int, default=DURATION,
                         help='Credential duration ($DURATION)')
     parser.add_argument('-p', '--profile', default=PROFILE,
-                        help='AWS profile ($AWS_PROFILE)')
+                        help='AWS profile ($AWS_PROFILE) (defaults to \'sts\')')
     parser.add_argument('-a', '--ask-role', default=ASK_ROLE,
                         action='store_true', help='Set true to always pick the role')
     parser.add_argument('-V', '--version', action='version',

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -371,7 +371,7 @@ def parse_args(args):
     parser.add_argument('-d', '--duration', type=int, default=DURATION,
                         help='Credential duration ($DURATION)')
     parser.add_argument('-p', '--profile', default=PROFILE,
-                        help='AWS profile ($AWS_PROFILE) (defaults to \'sts\')')
+                        help='AWS profile (defaults to value of $AWS_PROFILE, then falls back to \'sts\')')
     parser.add_argument('-a', '--ask-role', default=ASK_ROLE,
                         action='store_true', help='Set true to always pick the role')
     parser.add_argument('-V', '--version', action='version',

--- a/aws_google_auth/prepare.py
+++ b/aws_google_auth/prepare.py
@@ -17,7 +17,8 @@ def get_prepared_config(
     def default_if_none(value, default):
         return value if value is not None else default
 
-    google_config.profile = default_if_none(profile, google_config.profile)
+    # If no profile is specified, default to "sts" so we don't clobber the user's default.
+    google_config.profile = default_if_none(profile, google_config.profile) or "sts"
     _create_base_aws_cli_config_files_if_needed(google_config)
 
     if google_config.profile is not None:

--- a/aws_google_auth/tests/test_persist_profile.py
+++ b/aws_google_auth/tests/test_persist_profile.py
@@ -102,4 +102,4 @@ class TestPersistConfig(unittest.TestCase):
         self.assertEquals(config.google_sp_id, None)
         self.assertEquals(config.duration, 3600)
         self.assertEquals(config.ask_role, False)
-        self.assertEquals(config.profile, None)
+        self.assertEquals(config.profile, "sts")


### PR DESCRIPTION
This fixes #22 (replaces PR #32), a bug that caused the AWS credentials to become corrupted by inserting a `[None]` section into the configuration. Since it doesn't make sense to write to a saved profile if one isn't set, it will just export instead.

It's likely the case people will have `[default]` in use, so to prevent clobbering we'll default to `sts` instead. Of course, if the user wants to specify a profile they can. The profile `[sts]` was chosen based on the [`aws_role_credentials`](https://github.com/ThoughtWorksInc/aws_role_credentials/blob/master/README.rst#options) project.

* Before this patch, if someone ran this script with no profile, the` ~/.aws/(config|credentials)` would not have been modified.
* After this patch, the AWS config will be updated.