### PR TITLE
Resolve AWS account aliases (if possible) and print them to the users

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -167,7 +167,8 @@ def cli(cli_args):
     if config.role_arn in roles and not config.ask_role:
         config.provider = roles[config.role_arn]
     else:
-        config.role_arn, config.provider = util.Util.pick_a_role(roles)
+        aliases = amazon_client.resolve_aws_aliases(roles)
+        config.role_arn, config.provider = util.Util.pick_a_role(roles, aliases)
 
     print("Assuming " + config.role_arn)
     print("Credentials Expiration: " + format(amazon_client.expiration.astimezone(get_localzone())))

--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -85,7 +85,14 @@ class Amazon:
                 account_alias = response['AccountAliases'][0]
                 aws_dict[role.split(':')[4]] = account_alias
             except:
-                aws_dict[role.split(':')[4]] = "AliasNotAvailable"
+                sts = boto3.client('sts',
+                                   aws_access_key_id=saml['Credentials']['AccessKeyId'],
+                                   aws_secret_access_key=saml['Credentials']['SecretAccessKey'],
+                                   aws_session_token=saml['Credentials']['SessionToken'],
+                                   region_name=self.config.region)
+
+                account_id = sts.get_caller_identity().get('Account')
+                aws_dict[role.split(':')[4]] = 'Account {}'.format(account_id)
 
         threads = []
         aws_id_alias = {}

--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -92,7 +92,7 @@ class Amazon:
                                    region_name=self.config.region)
 
                 account_id = sts.get_caller_identity().get('Account')
-                aws_dict[role.split(':')[4]] = 'Account {}'.format(account_id)
+                aws_dict[role.split(':')[4]] = '{}'.format(account_id)
 
         threads = []
         aws_id_alias = {}

--- a/aws_google_auth/configuration.py
+++ b/aws_google_auth/configuration.py
@@ -25,6 +25,7 @@ class Configuration:
         self.__saml_cache = None
         self.sp_id = None
         self.u2f_disabled = False
+        self.resolve_aliases = False
         self.username = None
 
     # For the "~/.aws/config" file, we use the format "[profile testing]"

--- a/aws_google_auth/util.py
+++ b/aws_google_auth/util.py
@@ -2,6 +2,7 @@
 
 import os
 from collections import OrderedDict
+from tabulate import tabulate
 
 
 class Util:
@@ -23,16 +24,18 @@ class Util:
                     role.split('role/')[1],
                     principal
                 ]
-            enriched_roles = OrderedDict(sorted(enriched_roles.items(), key=lambda t: t[1]))
+            enriched_roles = OrderedDict(sorted(enriched_roles.items(), key=lambda t: (t[1][0], t[1][1])))
 
             ordered_roles = OrderedDict()
             for role, role_property in enriched_roles.items():
                 ordered_roles[role] = role_property[2]
 
-            while True:
-                for i, (role, role_property) in enumerate(enriched_roles.items()):
-                    print("[{:>3d}] {}@{}".format(i + 1, role_property[0], role_property[1]))
+            enriched_roles_tab = []
+            for i, (role, role_property) in enumerate(enriched_roles.items()):
+                enriched_roles_tab.append([i + 1, role_property[0], role_property[1]])
 
+            while True:
+                print(tabulate(enriched_roles_tab, headers=['No', 'AWS account', 'Role'], ))
                 prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(enriched_roles))
                 choice = Util.get_input(prompt)
 

--- a/aws_google_auth/util.py
+++ b/aws_google_auth/util.py
@@ -14,27 +14,40 @@ class Util:
             return input(prompt)
 
     @staticmethod
-    def pick_a_role(roles, aliases):
-        enriched_roles = {}
-        for role, principal in roles.items():
-            enriched_roles['{} {}'.format(aliases[role.split(':')[4]], role)] = principal
-        enriched_roles = OrderedDict(sorted(enriched_roles.items(), key=lambda t: t[0]))
+    def pick_a_role(roles, aliases=None):
+        if aliases:
+            enriched_roles = {}
+            for role, principal in roles.items():
+                enriched_roles['{} {}'.format(aliases[role.split(':')[4]], role)] = principal
+            enriched_roles = OrderedDict(sorted(enriched_roles.items(), key=lambda t: t[0]))
 
-        ordered_roles = OrderedDict()
-        for role, principal in enriched_roles.items():
-            ordered_roles[role.split(' ')[1]] = principal
+            ordered_roles = OrderedDict()
+            for role, principal in enriched_roles.items():
+                ordered_roles[role.split(' ')[1]] = principal
 
-        while True:
-            for i, role in enumerate(enriched_roles):
-                print("[{:>3d}] {}".format(i + 1, role))
+            while True:
+                for i, role in enumerate(enriched_roles):
+                    print("[{:>3d}] {}".format(i + 1, role))
 
-            prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(enriched_roles))
-            choice = Util.get_input(prompt)
+                prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(enriched_roles))
+                choice = Util.get_input(prompt)
 
-            try:
-                return list(ordered_roles.items())[int(choice) - 1]
-            except IndexError:
-                print("Invalid choice, try again.")
+                try:
+                    return list(ordered_roles.items())[int(choice) - 1]
+                except IndexError:
+                    print("Invalid choice, try again.")
+        else:
+            while True:
+                for i, role in enumerate(roles):
+                    print("[{:>3d}] {}".format(i + 1, role))
+
+                prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(roles))
+                choice = Util.get_input(prompt)
+
+                try:
+                    return list(roles.items())[int(choice) - 1]
+                except IndexError:
+                    print("Invalid choice, try again.")
 
     @staticmethod
     def touch(file_name, mode=0o600):

--- a/aws_google_auth/util.py
+++ b/aws_google_auth/util.py
@@ -18,16 +18,20 @@ class Util:
         if aliases:
             enriched_roles = {}
             for role, principal in roles.items():
-                enriched_roles['{} {}'.format(aliases[role.split(':')[4]], role)] = principal
-            enriched_roles = OrderedDict(sorted(enriched_roles.items(), key=lambda t: t[0]))
+                enriched_roles[role] = [
+                    aliases[role.split(':')[4]],
+                    role.split('role/')[1],
+                    principal
+                ]
+            enriched_roles = OrderedDict(sorted(enriched_roles.items(), key=lambda t: t[1]))
 
             ordered_roles = OrderedDict()
-            for role, principal in enriched_roles.items():
-                ordered_roles[role.split(' ')[1]] = principal
+            for role, role_property in enriched_roles.items():
+                ordered_roles[role] = role_property[2]
 
             while True:
-                for i, role in enumerate(enriched_roles):
-                    print("[{:>3d}] {}".format(i + 1, role))
+                for i, (role, role_property) in enumerate(enriched_roles.items()):
+                    print("[{:>3d}] {}@{}".format(i + 1, role_property[0], role_property[1]))
 
                 prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(enriched_roles))
                 choice = Util.get_input(prompt)

--- a/aws_google_auth/util.py
+++ b/aws_google_auth/util.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+from collections import OrderedDict
 
 
 class Util:
@@ -13,16 +14,25 @@ class Util:
             return input(prompt)
 
     @staticmethod
-    def pick_a_role(roles):
+    def pick_a_role(roles, aliases):
+        enriched_roles = {}
+        for role, principal in roles.items():
+            enriched_roles['{} {}'.format(aliases[role.split(':')[4]], role)] = principal
+        enriched_roles = OrderedDict(sorted(enriched_roles.items(), key=lambda t: t[0]))
+
+        ordered_roles = OrderedDict()
+        for role, principal in enriched_roles.items():
+            ordered_roles[role.split(' ')[1]] = principal
+
         while True:
-            for i, role in enumerate(roles):
+            for i, role in enumerate(enriched_roles):
                 print("[{:>3d}] {}".format(i + 1, role))
 
-            prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(roles))
+            prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(enriched_roles))
             choice = Util.get_input(prompt)
 
             try:
-                return list(roles.items())[int(choice) - 1]
+                return list(ordered_roles.items())[int(choice) - 1]
             except IndexError:
                 print("Invalid choice, try again.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ boto3
 configparser
 lxml
 requests
+tabulate

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     # install_requires=['peppercorn'],
     install_requires=['boto3', 'lxml', 'requests', 'beautifulsoup4',
-        'configparser', 'tzlocal'],
+        'configparser', 'tzlocal', 'tabulate'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This change allows to print AWS account alias and role ARN when `-a` option is used. It's easier to select correct account when alias is printed, especially when we have set of roles called "Administrator" across accounts. 