### PR TITLE
Add SAML Assertion Caching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,17 +88,14 @@ Usage
 
 .. code:: shell
 
-    $ aws-google-auth --help
-    usage: aws-google-auth [-h] [-v] [-u USERNAME] [-I IDP_ID] [-S SP_ID]
-                           [-R REGION] [-d DURATION] [-p PROFILE]
-                           [-r AWS_ROLE_ARN ]
+    $ aws-google-auth -h
+    usage: aws-google-auth [-h] [-u USERNAME] [-I IDP_ID] [-S SP_ID] [-R REGION]
+                           [-d DURATION] [-p PROFILE] [-D] [-a | -r ROLE_ARN] [-V]
 
     Acquire temporary AWS credentials via Google SSO
 
     optional arguments:
       -h, --help            show this help message and exit
-      -v, --version         show program's version number and exit
-
       -u USERNAME, --username USERNAME
                             Google Apps username ($GOOGLE_USERNAME)
       -I IDP_ID, --idp-id IDP_ID
@@ -110,12 +107,13 @@ Usage
       -d DURATION, --duration DURATION
                             Credential duration ($DURATION)
       -p PROFILE, --profile PROFILE
-                            AWS profile (defaults to value of $AWS_PROFILE,
-                            then falls back to 'sts')
-      -a ASK_ROLE, --ask-role ASK_ROLE
-                            Set true to always pick the role
-      -r AWS_ROLE_ARN, --role-arn AWS_ROLE_ARN
+                            AWS profile (defaults to value of $AWS_PROFILE, then
+                            falls back to 'sts')
+      -D, --disable-u2f     Disable U2F functionality.
+      -a, --ask-role        Set true to always pick the role
+      -r ROLE_ARN, --role-arn ROLE_ARN
                             The ARN of the role to assume
+      -V, --version         show program's version number and exit
 
 
 Native Python

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,8 @@ Usage
 
     $ aws-google-auth -h
     usage: aws-google-auth [-h] [-u USERNAME] [-I IDP_ID] [-S SP_ID] [-R REGION]
-                           [-d DURATION] [-p PROFILE] [-D] [-a | -r ROLE_ARN] [-V]
+                           [-d DURATION] [-p PROFILE] [-D] [--no-cache]
+                           [-a | -r ROLE_ARN] [-V]
 
     Acquire temporary AWS credentials via Google SSO
 
@@ -110,6 +111,7 @@ Usage
                             AWS profile (defaults to value of $AWS_PROFILE, then
                             falls back to 'sts')
       -D, --disable-u2f     Disable U2F functionality.
+      --no-cache            Do not cache the SAML Assertion.
       -a, --ask-role        Set true to always pick the role
       -r ROLE_ARN, --role-arn ROLE_ARN
                             The ARN of the role to assume

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -26,7 +26,7 @@ def parse_args(args):
     parser.add_argument('-d', '--duration', type=int, help='Credential duration ($DURATION)')
     parser.add_argument('-p', '--profile', help='AWS profile (defaults to value of $AWS_PROFILE, then falls back to \'sts\')')
     parser.add_argument('-D', '--disable-u2f', action='store_true', help='Disable U2F functionality.')
-    parser.add_argument('-c', '--saml-cache', action='store_true', help='Cache the SAML Assertion.')
+    parser.add_argument('--no-cache', dest="saml_cache", action='store_false', help='Do not cache the SAML Assertion.')
 
     role_group = parser.add_mutually_exclusive_group()
     role_group.add_argument('-a', '--ask-role', action='store_true', help='Set true to always pick the role')

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -26,6 +26,7 @@ def parse_args(args):
     parser.add_argument('-d', '--duration', type=int, help='Credential duration ($DURATION)')
     parser.add_argument('-p', '--profile', help='AWS profile (defaults to value of $AWS_PROFILE, then falls back to \'sts\')')
     parser.add_argument('-D', '--disable-u2f', action='store_true', help='Disable U2F functionality.')
+    parser.add_argument('-c', '--saml-cache', action='store_true', help='Cache the SAML Assertion.')
 
     role_group = parser.add_mutually_exclusive_group()
     role_group.add_argument('-a', '--ask-role', action='store_true', help='Set true to always pick the role')
@@ -124,30 +125,42 @@ def cli(cli_args):
         os.getenv('GOOGLE_USERNAME'),
         config.username)
 
-    # There are some mandatory arguments. Make sure the user supplied them.
-    if config.username is None:
-        config.username = util.Util.get_input("Google username: ")
-    if config.idp_id is None:
-        config.idp_id = util.Util.get_input("Google IDP ID: ")
-    if config.sp_id is None:
-        config.sp_id = util.Util.get_input("Google SP ID: ")
+    # If there is a valid cache and the user opted to use it, use that instead
+    # of prompting the user for input (it will also ignroe any set variables
+    # such as username or sp_id and idp_id, as those are built into the SAML
+    # response). The user does not need to be prompted for a password if the
+    # SAML cache is used.
+    if args.saml_cache and config.saml_cache:
+        saml_xml = config.saml_cache
+    else:
+        # No cache, continue without.
+        if config.username is None:
+            config.username = util.Util.get_input("Google username: ")
+        if config.idp_id is None:
+            config.idp_id = util.Util.get_input("Google IDP ID: ")
+        if config.sp_id is None:
+            config.sp_id = util.Util.get_input("Google SP ID: ")
 
-    # There is no way (intentional) to pass in the password via the command
-    # line nor environment variables. This prevents password leakage.
-    config.password = getpass.getpass("Google Password: ")
+        # There is no way (intentional) to pass in the password via the command
+        # line nor environment variables. This prevents password leakage.
+        config.password = getpass.getpass("Google Password: ")
 
-    # Validate Options
-    try:
+        # Validate Options
         config.raise_if_invalid()
-    except AssertionError:
-        print("Invalid parameters.")
-        raise
 
-    google_client = google.Google(config)
-    google_client.do_login()
-    encoded_saml = google_client.parse_saml()
+        google_client = google.Google(config)
+        google_client.do_login()
+        saml_xml = google_client.parse_saml()
 
-    amazon_client = amazon.Amazon(config, encoded_saml)
+        # We now have a new SAML value that can get cached (If the user asked
+        # for it to be)
+        if args.saml_cache:
+            config.saml_cache = saml_xml
+
+    # The amazon_client now has the SAML assertion it needed (Either via the
+    # cache or freshly generated). From here, we can get the roles and continue
+    # the rest of the workflow regardless of cache.
+    amazon_client = amazon.Amazon(config, saml_xml)
     roles = amazon_client.roles
 
     # Determine the provider and the role arn (if the the user provided isn't an option)

--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -84,13 +84,8 @@ class Amazon:
             not_on_or_after = datetime.strptime(not_on_or_after_str, "%Y-%m-%dT%H:%M:%S.%fZ")
 
             if not_before <= now < not_on_or_after:
-                # print("VALID")
-                # print("Valid for another {}".format(not_on_or_after - now))
                 return True
             else:
-                # print("INVALID/EXPIRED")
-                # print(not_before)
-                # print(not_on_or_after)
                 return False
         except Exception as e:
             print(e)

--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -87,6 +87,5 @@ class Amazon:
                 return True
             else:
                 return False
-        except Exception as e:
-            print(e)
+        except Exception:
             return False

--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -3,13 +3,14 @@
 import boto3
 import base64
 from lxml import etree
+from datetime import datetime
 
 
 class Amazon:
 
-    def __init__(self, config, encoded_saml):
+    def __init__(self, config, saml_xml):
         self.config = config
-        self.encoded_saml = encoded_saml
+        self.saml_xml = saml_xml
         self.__token = None
 
     @property
@@ -17,8 +18,8 @@ class Amazon:
         return boto3.client('sts', region_name=self.config.region)
 
     @property
-    def decoded_saml(self):
-        return base64.b64decode(self.encoded_saml)
+    def base64_encoded_saml(self):
+        return base64.b64encode(self.saml_xml).decode("utf-8")
 
     @property
     def token(self):
@@ -26,7 +27,7 @@ class Amazon:
             self.__token = self.sts_client.assume_role_with_saml(
                 RoleArn=self.config.role_arn,
                 PrincipalArn=self.config.provider,
-                SAMLAssertion=self.encoded_saml,
+                SAMLAssertion=self.base64_encoded_saml,
                 DurationSeconds=self.config.duration)
         return self.__token
 
@@ -59,10 +60,38 @@ class Amazon:
 
     @property
     def roles(self):
-        doc = etree.fromstring(self.decoded_saml)
+        doc = etree.fromstring(self.saml_xml)
         roles = {}
         for x in doc.xpath('//*[@Name = "https://aws.amazon.com/SAML/Attributes/Role"]//text()'):
             if "arn:aws:iam:" in x:
                 res = x.split(',')
                 roles[res[0]] = res[1]
         return roles
+
+    @staticmethod
+    def is_valid_saml_assertion(saml_xml):
+        if saml_xml is None:
+            return False
+
+        try:
+            doc = etree.fromstring(saml_xml)
+            conditions = list(doc.iter(tag='{urn:oasis:names:tc:SAML:2.0:assertion}Conditions'))
+            not_before_str = conditions[0].get('NotBefore')
+            not_on_or_after_str = conditions[0].get('NotOnOrAfter')
+
+            now = datetime.utcnow()
+            not_before = datetime.strptime(not_before_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+            not_on_or_after = datetime.strptime(not_on_or_after_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+
+            if not_before <= now < not_on_or_after:
+                # print("VALID")
+                # print("Valid for another {}".format(not_on_or_after - now))
+                return True
+            else:
+                # print("INVALID/EXPIRED")
+                # print(not_before)
+                # print(not_on_or_after)
+                return False
+        except Exception as e:
+            print(e)
+            return False

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -5,6 +5,7 @@ from . import _version
 import sys
 import requests
 import json
+import base64
 from bs4 import BeautifulSoup
 
 # In Python3, the library 'urlparse' was renamed to 'urllib.parse'. For this to
@@ -151,7 +152,7 @@ class Google:
         except:
             raise RuntimeError('Could not find SAML response, check your credentials')
 
-        return saml_element
+        return base64.b64decode(saml_element)
 
     def handle_sk(self, sess):
         response_page = BeautifulSoup(sess.text, 'html.parser')

--- a/aws_google_auth/tests/saml-response-expired-before-valid.xml
+++ b/aws_google_auth/tests/saml-response-expired-before-valid.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" Destination="https://signin.aws.amazon.com/saml" ID="_7c434be06bf79a781dae9e7ed0024679" IssueInstant="2017-07-24T10:31:41.125Z" Version="2.0">
+  <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://accounts.google.com/o/saml2?idpid=abcd12345</saml2:Issuer>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_b1dd2c0469d905dfb1e10751d6feae95" IssueInstant="2017-07-24T10:31:41.125Z" Version="2.0">
+    <saml2:Issuer>https://accounts.google.com/o/saml2?idpid=abcd12345</saml2:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference URI="#_b1dd2c0469d905dfb1e10751d6feae95">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>GbaJHVPpMT7JJEn+DtohU/tzd5b/BiZ9+It3sd2LB5Y=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>dJxZmFNw+rY07AV7Ex1Kbvn9ZiGE4VKwYELwxkrejgEiVeAteyaw8rQfeHDF1UhZJ/2JTHWs3uk+
+VoWZcI1qcWO3HRjZ/jz7DXH/QGVIBYe447sr9o2RC2WfpjAYTDJ5rN5nPmrQKXxREfFzsZXJutcj
+iPGXDNCC4SsWmKDaqbpWiDKhw+wRxtGxEXB2Ny11dRL6sCIHCdq86H55EXcq2YqL5I/ryMcWt3L0
+SZ5B9aq80omhear/24M1HyL35dmxVUFODrYBxMQ+7Lw6/XUCA2k60MjcsHQW+BJZGwFJBL0HJywu
+bc10BKTA89jbXyBtdoagtWRhF6LJzjL5bImLGA==</ds:SignatureValue>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509SubjectName>ST=California,C=US,OU=Google For Work,CN=Google,L=Mountain View,O=Google Inc.</ds:X509SubjectName>
+          <ds:X509Certificate>MIIDdDCCAlygAwIBAgIGAVXC/OcnMA0GCSqGSIb3DQEBCwUAMHsxFDASBgNVBAoTC0dvb2dsZSBJ
+bmMuMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MQ8wDQYDVQQDEwZHb29nbGUxGDAWBgNVBAsTD0dv
+b2dsZSBGb3IgV29yazELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWEwHhcNMTYwNzA3
+MDEzMzE5WhcNMjEwNzA2MDEzMzE5WjB7MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzEPMA0GA1UEAxMGR29vZ2xlMRgwFgYDVQQLEw9Hb29nbGUgRm9yIFdvcmsx
+CzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAhkv0Sr7ALfc58YrnLXzVGfTRg1T9xUfuZqhdu80BgHTfaJDLX66icHHRRoso/hho
+EIYo1pUQTq0DtgmqkLg9rAup3rR+pImfcHBC55+vMDoEf5t88H/i0qDn3r63PxeULRoFIkCX9aVG
+uUPDe2CHAxB1UXUxyDf7ZAdIQJLPJdOQlsNRleBBoek4vuo2ZHv+A2tbAhE8/rIoQlDvXSpCZ9P7
+m9TrFOb7tB4pHjJjESdmqcnEFc5zepAT8IuRAGZ1OkjJs74JUp+03do8scTMXzvVi4jefpyXhnoN
+C0da4OwPig7UmbDsrSCGbqz29UgxmGUmSnLchpkglw1eET5hTwIDAQABMA0GCSqGSIb3DQEBCwUA
+A4IBAQAA5WBtCPlaSIm1NIpKYd2x8qfeKc2YsxbAPukgUFaRDl1uxGw1HdzNzUp9X4JOF/futpw/
+yhmw9o1GHBukIdj0mJRt8O9szRdkJmx4EfbY5bTVzkQ7QGv9FI1LBD6z6KgJEOxEGpDbh2Z8uyW8
+HvxXgZgiyan53FauVJe+UuAkBy2ynJcVKK3+vUEISFXn1oh5SPOmi+2R4WKSgyTqOKpuowHHHg9u
+EbwwnXPMU4q3QLG1oDrp0ZvVuprvJaoWd5zIt/TYB3Hb5oEO7Imwx1n9K9QskYmFygR9rdJ6VS7L
+6/h6rcL/dKjm4pU0Dgk9h9Hi8ps7Mn+nRRhsWQbiD59n</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </ds:Signature>
+    <saml2:Subject>
+      <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">first.last@example.com</saml2:NameID>
+      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml2:SubjectConfirmationData NotOnOrAfter="2017-07-24T10:36:41.125Z" Recipient="https://signin.aws.amazon.com/saml"/>
+      </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <!-- This will always be invalid for tests, the NotBefore is after the NotOnOrAfter -->
+    <saml2:Conditions NotBefore="2100-07-24T10:26:41.125Z" NotOnOrAfter="2011-07-24T10:36:41.125Z">
+      <saml2:AudienceRestriction>
+        <saml2:Audience>https://signin.aws.amazon.com/saml</saml2:Audience>
+      </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/RoleSessionName">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">first.last@example.com</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/admin,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/read-only,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/test,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/SessionDuration">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">28800</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+    <saml2:AuthnStatement AuthnInstant="2017-07-24T10:31:38.000Z" SessionIndex="_b1dd2c0469d905dfb1e10751d6feae95">
+      <saml2:AuthnContext>
+        <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml2:AuthnContextClassRef>
+      </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+  </saml2:Assertion>
+</saml2p:Response>

--- a/aws_google_auth/tests/saml-response-no-expire.xml
+++ b/aws_google_auth/tests/saml-response-no-expire.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" Destination="https://signin.aws.amazon.com/saml" ID="_7c434be06bf79a781dae9e7ed0024679" IssueInstant="2017-07-24T10:31:41.125Z" Version="2.0">
+  <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://accounts.google.com/o/saml2?idpid=abcd12345</saml2:Issuer>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_b1dd2c0469d905dfb1e10751d6feae95" IssueInstant="2017-07-24T10:31:41.125Z" Version="2.0">
+    <saml2:Issuer>https://accounts.google.com/o/saml2?idpid=abcd12345</saml2:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference URI="#_b1dd2c0469d905dfb1e10751d6feae95">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>GbaJHVPpMT7JJEn+DtohU/tzd5b/BiZ9+It3sd2LB5Y=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>dJxZmFNw+rY07AV7Ex1Kbvn9ZiGE4VKwYELwxkrejgEiVeAteyaw8rQfeHDF1UhZJ/2JTHWs3uk+
+VoWZcI1qcWO3HRjZ/jz7DXH/QGVIBYe447sr9o2RC2WfpjAYTDJ5rN5nPmrQKXxREfFzsZXJutcj
+iPGXDNCC4SsWmKDaqbpWiDKhw+wRxtGxEXB2Ny11dRL6sCIHCdq86H55EXcq2YqL5I/ryMcWt3L0
+SZ5B9aq80omhear/24M1HyL35dmxVUFODrYBxMQ+7Lw6/XUCA2k60MjcsHQW+BJZGwFJBL0HJywu
+bc10BKTA89jbXyBtdoagtWRhF6LJzjL5bImLGA==</ds:SignatureValue>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509SubjectName>ST=California,C=US,OU=Google For Work,CN=Google,L=Mountain View,O=Google Inc.</ds:X509SubjectName>
+          <ds:X509Certificate>MIIDdDCCAlygAwIBAgIGAVXC/OcnMA0GCSqGSIb3DQEBCwUAMHsxFDASBgNVBAoTC0dvb2dsZSBJ
+bmMuMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MQ8wDQYDVQQDEwZHb29nbGUxGDAWBgNVBAsTD0dv
+b2dsZSBGb3IgV29yazELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWEwHhcNMTYwNzA3
+MDEzMzE5WhcNMjEwNzA2MDEzMzE5WjB7MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzEPMA0GA1UEAxMGR29vZ2xlMRgwFgYDVQQLEw9Hb29nbGUgRm9yIFdvcmsx
+CzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAhkv0Sr7ALfc58YrnLXzVGfTRg1T9xUfuZqhdu80BgHTfaJDLX66icHHRRoso/hho
+EIYo1pUQTq0DtgmqkLg9rAup3rR+pImfcHBC55+vMDoEf5t88H/i0qDn3r63PxeULRoFIkCX9aVG
+uUPDe2CHAxB1UXUxyDf7ZAdIQJLPJdOQlsNRleBBoek4vuo2ZHv+A2tbAhE8/rIoQlDvXSpCZ9P7
+m9TrFOb7tB4pHjJjESdmqcnEFc5zepAT8IuRAGZ1OkjJs74JUp+03do8scTMXzvVi4jefpyXhnoN
+C0da4OwPig7UmbDsrSCGbqz29UgxmGUmSnLchpkglw1eET5hTwIDAQABMA0GCSqGSIb3DQEBCwUA
+A4IBAQAA5WBtCPlaSIm1NIpKYd2x8qfeKc2YsxbAPukgUFaRDl1uxGw1HdzNzUp9X4JOF/futpw/
+yhmw9o1GHBukIdj0mJRt8O9szRdkJmx4EfbY5bTVzkQ7QGv9FI1LBD6z6KgJEOxEGpDbh2Z8uyW8
+HvxXgZgiyan53FauVJe+UuAkBy2ynJcVKK3+vUEISFXn1oh5SPOmi+2R4WKSgyTqOKpuowHHHg9u
+EbwwnXPMU4q3QLG1oDrp0ZvVuprvJaoWd5zIt/TYB3Hb5oEO7Imwx1n9K9QskYmFygR9rdJ6VS7L
+6/h6rcL/dKjm4pU0Dgk9h9Hi8ps7Mn+nRRhsWQbiD59n</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </ds:Signature>
+    <saml2:Subject>
+      <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">first.last@example.com</saml2:NameID>
+      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml2:SubjectConfirmationData NotOnOrAfter="2017-07-24T10:36:41.125Z" Recipient="https://signin.aws.amazon.com/saml"/>
+      </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <!-- This will always be valid for tests, hence the very far off NotOnOrAfter -->
+    <saml2:Conditions NotBefore="2010-07-24T10:26:41.125Z" NotOnOrAfter="2100-07-24T10:36:41.125Z">
+      <saml2:AudienceRestriction>
+        <saml2:Audience>https://signin.aws.amazon.com/saml</saml2:Audience>
+      </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/RoleSessionName">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">first.last@example.com</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/admin,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/read-only,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/test,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/SessionDuration">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">28800</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+    <saml2:AuthnStatement AuthnInstant="2017-07-24T10:31:38.000Z" SessionIndex="_b1dd2c0469d905dfb1e10751d6feae95">
+      <saml2:AuthnContext>
+        <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml2:AuthnContextClassRef>
+      </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+  </saml2:Assertion>
+</saml2p:Response>

--- a/aws_google_auth/tests/saml-response-too-late.xml
+++ b/aws_google_auth/tests/saml-response-too-late.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" Destination="https://signin.aws.amazon.com/saml" ID="_7c434be06bf79a781dae9e7ed0024679" IssueInstant="2017-07-24T10:31:41.125Z" Version="2.0">
+  <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://accounts.google.com/o/saml2?idpid=abcd12345</saml2:Issuer>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_b1dd2c0469d905dfb1e10751d6feae95" IssueInstant="2017-07-24T10:31:41.125Z" Version="2.0">
+    <saml2:Issuer>https://accounts.google.com/o/saml2?idpid=abcd12345</saml2:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference URI="#_b1dd2c0469d905dfb1e10751d6feae95">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>GbaJHVPpMT7JJEn+DtohU/tzd5b/BiZ9+It3sd2LB5Y=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>dJxZmFNw+rY07AV7Ex1Kbvn9ZiGE4VKwYELwxkrejgEiVeAteyaw8rQfeHDF1UhZJ/2JTHWs3uk+
+VoWZcI1qcWO3HRjZ/jz7DXH/QGVIBYe447sr9o2RC2WfpjAYTDJ5rN5nPmrQKXxREfFzsZXJutcj
+iPGXDNCC4SsWmKDaqbpWiDKhw+wRxtGxEXB2Ny11dRL6sCIHCdq86H55EXcq2YqL5I/ryMcWt3L0
+SZ5B9aq80omhear/24M1HyL35dmxVUFODrYBxMQ+7Lw6/XUCA2k60MjcsHQW+BJZGwFJBL0HJywu
+bc10BKTA89jbXyBtdoagtWRhF6LJzjL5bImLGA==</ds:SignatureValue>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509SubjectName>ST=California,C=US,OU=Google For Work,CN=Google,L=Mountain View,O=Google Inc.</ds:X509SubjectName>
+          <ds:X509Certificate>MIIDdDCCAlygAwIBAgIGAVXC/OcnMA0GCSqGSIb3DQEBCwUAMHsxFDASBgNVBAoTC0dvb2dsZSBJ
+bmMuMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MQ8wDQYDVQQDEwZHb29nbGUxGDAWBgNVBAsTD0dv
+b2dsZSBGb3IgV29yazELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWEwHhcNMTYwNzA3
+MDEzMzE5WhcNMjEwNzA2MDEzMzE5WjB7MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzEPMA0GA1UEAxMGR29vZ2xlMRgwFgYDVQQLEw9Hb29nbGUgRm9yIFdvcmsx
+CzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAhkv0Sr7ALfc58YrnLXzVGfTRg1T9xUfuZqhdu80BgHTfaJDLX66icHHRRoso/hho
+EIYo1pUQTq0DtgmqkLg9rAup3rR+pImfcHBC55+vMDoEf5t88H/i0qDn3r63PxeULRoFIkCX9aVG
+uUPDe2CHAxB1UXUxyDf7ZAdIQJLPJdOQlsNRleBBoek4vuo2ZHv+A2tbAhE8/rIoQlDvXSpCZ9P7
+m9TrFOb7tB4pHjJjESdmqcnEFc5zepAT8IuRAGZ1OkjJs74JUp+03do8scTMXzvVi4jefpyXhnoN
+C0da4OwPig7UmbDsrSCGbqz29UgxmGUmSnLchpkglw1eET5hTwIDAQABMA0GCSqGSIb3DQEBCwUA
+A4IBAQAA5WBtCPlaSIm1NIpKYd2x8qfeKc2YsxbAPukgUFaRDl1uxGw1HdzNzUp9X4JOF/futpw/
+yhmw9o1GHBukIdj0mJRt8O9szRdkJmx4EfbY5bTVzkQ7QGv9FI1LBD6z6KgJEOxEGpDbh2Z8uyW8
+HvxXgZgiyan53FauVJe+UuAkBy2ynJcVKK3+vUEISFXn1oh5SPOmi+2R4WKSgyTqOKpuowHHHg9u
+EbwwnXPMU4q3QLG1oDrp0ZvVuprvJaoWd5zIt/TYB3Hb5oEO7Imwx1n9K9QskYmFygR9rdJ6VS7L
+6/h6rcL/dKjm4pU0Dgk9h9Hi8ps7Mn+nRRhsWQbiD59n</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </ds:Signature>
+    <saml2:Subject>
+      <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">first.last@example.com</saml2:NameID>
+      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml2:SubjectConfirmationData NotOnOrAfter="2017-07-24T10:36:41.125Z" Recipient="https://signin.aws.amazon.com/saml"/>
+      </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <!-- This will always be invalid for tests, hence the very far off NotBefore and NotOnOrAfter -->
+    <saml2:Conditions NotBefore="2010-07-24T10:26:41.125Z" NotOnOrAfter="2011-07-24T10:36:41.125Z">
+      <saml2:AudienceRestriction>
+        <saml2:Audience>https://signin.aws.amazon.com/saml</saml2:Audience>
+      </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/RoleSessionName">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">first.last@example.com</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/admin,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/read-only,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/test,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/SessionDuration">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">28800</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+    <saml2:AuthnStatement AuthnInstant="2017-07-24T10:31:38.000Z" SessionIndex="_b1dd2c0469d905dfb1e10751d6feae95">
+      <saml2:AuthnContext>
+        <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml2:AuthnContextClassRef>
+      </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+  </saml2:Assertion>
+</saml2p:Response>

--- a/aws_google_auth/tests/saml-response-too-soon.xml
+++ b/aws_google_auth/tests/saml-response-too-soon.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" Destination="https://signin.aws.amazon.com/saml" ID="_7c434be06bf79a781dae9e7ed0024679" IssueInstant="2017-07-24T10:31:41.125Z" Version="2.0">
+  <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://accounts.google.com/o/saml2?idpid=abcd12345</saml2:Issuer>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_b1dd2c0469d905dfb1e10751d6feae95" IssueInstant="2017-07-24T10:31:41.125Z" Version="2.0">
+    <saml2:Issuer>https://accounts.google.com/o/saml2?idpid=abcd12345</saml2:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference URI="#_b1dd2c0469d905dfb1e10751d6feae95">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>GbaJHVPpMT7JJEn+DtohU/tzd5b/BiZ9+It3sd2LB5Y=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>dJxZmFNw+rY07AV7Ex1Kbvn9ZiGE4VKwYELwxkrejgEiVeAteyaw8rQfeHDF1UhZJ/2JTHWs3uk+
+VoWZcI1qcWO3HRjZ/jz7DXH/QGVIBYe447sr9o2RC2WfpjAYTDJ5rN5nPmrQKXxREfFzsZXJutcj
+iPGXDNCC4SsWmKDaqbpWiDKhw+wRxtGxEXB2Ny11dRL6sCIHCdq86H55EXcq2YqL5I/ryMcWt3L0
+SZ5B9aq80omhear/24M1HyL35dmxVUFODrYBxMQ+7Lw6/XUCA2k60MjcsHQW+BJZGwFJBL0HJywu
+bc10BKTA89jbXyBtdoagtWRhF6LJzjL5bImLGA==</ds:SignatureValue>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509SubjectName>ST=California,C=US,OU=Google For Work,CN=Google,L=Mountain View,O=Google Inc.</ds:X509SubjectName>
+          <ds:X509Certificate>MIIDdDCCAlygAwIBAgIGAVXC/OcnMA0GCSqGSIb3DQEBCwUAMHsxFDASBgNVBAoTC0dvb2dsZSBJ
+bmMuMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MQ8wDQYDVQQDEwZHb29nbGUxGDAWBgNVBAsTD0dv
+b2dsZSBGb3IgV29yazELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWEwHhcNMTYwNzA3
+MDEzMzE5WhcNMjEwNzA2MDEzMzE5WjB7MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzEPMA0GA1UEAxMGR29vZ2xlMRgwFgYDVQQLEw9Hb29nbGUgRm9yIFdvcmsx
+CzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAhkv0Sr7ALfc58YrnLXzVGfTRg1T9xUfuZqhdu80BgHTfaJDLX66icHHRRoso/hho
+EIYo1pUQTq0DtgmqkLg9rAup3rR+pImfcHBC55+vMDoEf5t88H/i0qDn3r63PxeULRoFIkCX9aVG
+uUPDe2CHAxB1UXUxyDf7ZAdIQJLPJdOQlsNRleBBoek4vuo2ZHv+A2tbAhE8/rIoQlDvXSpCZ9P7
+m9TrFOb7tB4pHjJjESdmqcnEFc5zepAT8IuRAGZ1OkjJs74JUp+03do8scTMXzvVi4jefpyXhnoN
+C0da4OwPig7UmbDsrSCGbqz29UgxmGUmSnLchpkglw1eET5hTwIDAQABMA0GCSqGSIb3DQEBCwUA
+A4IBAQAA5WBtCPlaSIm1NIpKYd2x8qfeKc2YsxbAPukgUFaRDl1uxGw1HdzNzUp9X4JOF/futpw/
+yhmw9o1GHBukIdj0mJRt8O9szRdkJmx4EfbY5bTVzkQ7QGv9FI1LBD6z6KgJEOxEGpDbh2Z8uyW8
+HvxXgZgiyan53FauVJe+UuAkBy2ynJcVKK3+vUEISFXn1oh5SPOmi+2R4WKSgyTqOKpuowHHHg9u
+EbwwnXPMU4q3QLG1oDrp0ZvVuprvJaoWd5zIt/TYB3Hb5oEO7Imwx1n9K9QskYmFygR9rdJ6VS7L
+6/h6rcL/dKjm4pU0Dgk9h9Hi8ps7Mn+nRRhsWQbiD59n</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </ds:Signature>
+    <saml2:Subject>
+      <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">first.last@example.com</saml2:NameID>
+      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml2:SubjectConfirmationData NotOnOrAfter="2017-07-24T10:36:41.125Z" Recipient="https://signin.aws.amazon.com/saml"/>
+      </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <!-- This will always be invalid for tests, hence the very far off NotBefore and NotOnOrAfter -->
+    <saml2:Conditions NotBefore="2100-07-24T10:26:41.125Z" NotOnOrAfter="2100-07-24T10:36:41.125Z">
+      <saml2:AudienceRestriction>
+        <saml2:Audience>https://signin.aws.amazon.com/saml</saml2:Audience>
+      </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/RoleSessionName">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">first.last@example.com</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/admin,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/read-only,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">arn:aws:iam::123456789012:role/test,arn:aws:iam::123456789012:saml-provider/GoogleApps</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/SessionDuration">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:anyType">28800</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+    <saml2:AuthnStatement AuthnInstant="2017-07-24T10:31:38.000Z" SessionIndex="_b1dd2c0469d905dfb1e10751d6feae95">
+      <saml2:AuthnContext>
+        <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml2:AuthnContextClassRef>
+      </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+  </saml2:Assertion>
+</saml2p:Response>


### PR DESCRIPTION
This PR adds SAML Caching support. This will allow for `aws-google-auth` to be called multiple times without the user being prompted for a password or any two-factor tokens. 

I've added a handful of tests, and I'm trying to think of how to add more. 