### PR TITLE
Adds Docker builds to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ after_success:
 # to publish multiple times.
 jobs:
   include:
+  - stage: Docker Build Test
+    script: docker build -f Dockerfile .
+  - stage: Docker Build Test
+    script: docker build -f Dockerfile.python2 .
   - stage: deploy
     python: '2.7'
     install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ jobs:
   include:
   - stage: Docker Build Test
     script: docker build -f Dockerfile .
+    python: '3.6'
   - stage: Docker Build Test
     script: docker build -f Dockerfile.python2 .
+    python: '2.7'
   - stage: deploy
     python: '2.7'
     install: skip


### PR DESCRIPTION
It wouldn't hurt to have the Docker containers getting tested (the build process is a start). 

I noticed today that the Docker Hub builds failed; I'm not sure if this was due to a failure on their end, or an actual problem with the build - I'd be nice to have automated tests to tell us. 