### PR TITLE
Handle challenge selection and iap challenge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,11 @@ by this tool are:
 | SMS (or voice    | ``.../signin/challenge/ipp/2?...``  |
 |  call)           |                                     |
 +------------------+-------------------------------------+
+| SMS (or voice    | ``.../signin/challenge/iap/...``    |
+|  call) with      |                                     |
+|  number          |                                     |
+|  submission      |                                     |
++------------------+-------------------------------------+
 | Google Prompt    | ``.../signin/challenge/az/2?...``   |
 |  (phone app)     |                                     |
 +------------------+-------------------------------------+

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -136,6 +136,8 @@ class Google:
             sess = self.handle_prompt(sess)
         elif "challenge/sk/" in sess.url:
             sess = self.handle_sk(sess)
+        elif "challenge/iap/" in sess.url:
+            sess = self.handle_iap(sess)
 
         # ... there are different URLs for backup codes (printed)
         # and security keys (eg yubikey) as well
@@ -305,6 +307,74 @@ class Google:
         }
 
         # Submit TOTP
+        sess = self.session.post(challenge_url, data=payload)
+        sess.raise_for_status()
+
+        return sess
+
+    def handle_iap(self, sess):
+        response_page = BeautifulSoup(sess.text, 'html.parser')
+        challenge_url = sess.url.split("?")[0]
+        challenge_id = challenge_url.split("iap/")[1]
+        try:
+            phone_number = raw_input('Enter your phone number:') or None
+        except NameError:
+            phone_number = input('Enter your phone number:') or None
+
+        while True:
+            try:
+                choice = int(input('Type 1 to receive a code by SMS or 2 for a voice call:'))
+            except ValueError:
+                print("Not an integer! Try again.")
+                continue
+            else:
+                if choice == 1:
+                    send_method = 'SMS'
+                elif choice == 2:
+                    send_method = 'VOICE'
+                else:
+                    continue
+                break
+
+        payload = {
+            'challengeId': response_page.find('input', {'name': 'challengeId'}).get('value'),
+            'challengeType': response_page.find('input', {'name': 'challengeType'}).get('value'),
+            'continue': self.cont,
+            'scc': response_page.find('input', {'name': 'scc'}).get('value'),
+            'sarp': response_page.find('input', {'name': 'sarp'}).get('value'),
+            'checkedDomains': response_page.find('input', {'name': 'checkedDomains'}).get('value'),
+            'pstMsg': response_page.find('input', {'name': 'pstMsg'}).get('value'),
+            'TL': response_page.find('input', {'name': 'TL'}).get('value'),
+            'gxf': response_page.find('input', {'name': 'gxf'}).get('value'),
+            'phoneNumber': phone_number,
+            'sendMethod': send_method,
+        }
+
+        sess = self.session.post(challenge_url, data=payload)
+        sess.raise_for_status()
+
+        response_page = BeautifulSoup(sess.text, 'html.parser')
+        challenge_url = sess.url.split("?")[0]
+
+        try:
+            token = raw_input("Enter "+send_method+" token: G-") or None
+        except NameError:
+            token = input("Enter "+send_method+" token: G-") or None
+
+        payload = {
+            'challengeId': response_page.find('input', {'name': 'challengeId'}).get('value'),
+            'challengeType': response_page.find('input', {'name': 'challengeType'}).get('value'),
+            'continue': response_page.find('input', {'name': 'continue'}).get('value'),
+            'scc': response_page.find('input', {'name': 'scc'}).get('value'),
+            'sarp': response_page.find('input', {'name': 'sarp'}).get('value'),
+            'checkedDomains': response_page.find('input', {'name': 'checkedDomains'}).get('value'),
+            'pstMsg': response_page.find('input', {'name': 'pstMsg'}).get('value'),
+            'TL': response_page.find('input', {'name': 'TL'}).get('value'),
+            'gxf': response_page.find('input', {'name': 'gxf'}).get('value'),
+            'pin': token,
+        }
+
+        # Submit SMS/VOICE token
         sess = self.session.post(challenge_url, data=payload)
         sess.raise_for_status()
 


### PR DESCRIPTION
Using aws-google-auth from ec2 instances with various IP, I've encountered 2 new cases leading to 'RuntimeError: Could not find SAML response, check your credentials' :
- If a user already has a phone number associated, Google can ask to select a SMS or VOICE challenge, I propose to redirect automatically to handle_sms
- If a user have no phone number associated, Google can ask to submit a number and choose to receive a token by SMS or voice call. I propose a new function handle_iap