### PR TITLE
Introduce tests to the args parser configuration

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -32,6 +32,7 @@ def parse_args(args):
     role_group = parser.add_mutually_exclusive_group()
     role_group.add_argument('-a', '--ask-role', action='store_true', help='Set true to always pick the role')
     role_group.add_argument('-r', '--role-arn', help='The ARN of the role to assume')
+
     parser.add_argument('-V', '--version', action='version',
                         version='%(prog)s {version}'.format(version=_version.__version__))
 

--- a/aws_google_auth/tests/test_args_parser.py
+++ b/aws_google_auth/tests/test_args_parser.py
@@ -1,0 +1,70 @@
+from .. import parse_args
+
+import unittest
+
+
+class TestPythonFailOnVersion(unittest.TestCase):
+
+    def test_no_arguments(self):
+        parser = parse_args([])
+
+        self.assertTrue(parser.saml_cache)
+        self.assertFalse(parser.ask_role)
+        self.assertFalse(parser.resolve_aliases)
+        self.assertEqual(parser.duration, None)
+        self.assertEqual(parser.duration, None)
+        self.assertEqual(parser.idp_id, None)
+        self.assertEqual(parser.profile, None)
+        self.assertEqual(parser.region, None)
+        self.assertEqual(parser.role_arn, None)
+        self.assertEqual(parser.username, None)
+
+    def test_username(self):
+
+        parser = parse_args(['-u', 'username@gmail.com'])
+
+        self.assertTrue(parser.saml_cache)
+        self.assertFalse(parser.ask_role)
+        self.assertFalse(parser.resolve_aliases)
+        self.assertEqual(parser.duration, None)
+        self.assertEqual(parser.duration, None)
+        self.assertEqual(parser.idp_id, None)
+        self.assertEqual(parser.profile, None)
+        self.assertEqual(parser.region, None)
+        self.assertEqual(parser.role_arn, None)
+        self.assertEqual(parser.username, 'username@gmail.com')
+
+    def test_nocache(self):
+
+        parser = parse_args(['--no-cache'])
+
+        self.assertFalse(parser.saml_cache)
+        self.assertFalse(parser.ask_role)
+        self.assertFalse(parser.resolve_aliases)
+        self.assertEqual(parser.duration, None)
+        self.assertEqual(parser.duration, None)
+        self.assertEqual(parser.idp_id, None)
+        self.assertEqual(parser.profile, None)
+        self.assertEqual(parser.region, None)
+        self.assertEqual(parser.role_arn, None)
+        self.assertEqual(parser.username, None)
+
+    def test_resolvealiases(self):
+
+        parser = parse_args(['--resolve-aliases'])
+
+        self.assertTrue(parser.saml_cache)
+        self.assertFalse(parser.ask_role)
+        self.assertTrue(parser.resolve_aliases)
+        self.assertEqual(parser.duration, None)
+        self.assertEqual(parser.duration, None)
+        self.assertEqual(parser.idp_id, None)
+        self.assertEqual(parser.profile, None)
+        self.assertEqual(parser.region, None)
+        self.assertEqual(parser.role_arn, None)
+        self.assertEqual(parser.username, None)
+
+    def test_ask_and_supply_role(self):
+
+        with self.assertRaises(SystemExit) as se:
+            parse_args(['-a', '-r', 'da-role'])

--- a/aws_google_auth/tests/test_args_parser.py
+++ b/aws_google_auth/tests/test_args_parser.py
@@ -6,18 +6,29 @@ import unittest
 class TestPythonFailOnVersion(unittest.TestCase):
 
     def test_no_arguments(self):
+        """
+        This test case exists to validate the default settings of the args parser.
+        Changes that break these checks should be considered for backwards compatibility review.
+        :return:
+        """
         parser = parse_args([])
 
         self.assertTrue(parser.saml_cache)
         self.assertFalse(parser.ask_role)
         self.assertFalse(parser.resolve_aliases)
-        self.assertEqual(parser.duration, None)
+        self.assertFalse(parser.disable_u2f, None)
+
         self.assertEqual(parser.duration, None)
         self.assertEqual(parser.idp_id, None)
+        self.assertEqual(parser.sp_id, None)
         self.assertEqual(parser.profile, None)
         self.assertEqual(parser.region, None)
         self.assertEqual(parser.role_arn, None)
         self.assertEqual(parser.username, None)
+
+        # Assert the size of the parameter so that new parameters trigger a review of this function
+        # and the appropriate defaults are added here to track backwards compatibility in the future.
+        self.assertEqual(len(vars(parser)), 11)
 
     def test_username(self):
 
@@ -68,3 +79,12 @@ class TestPythonFailOnVersion(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as se:
             parse_args(['-a', '-r', 'da-role'])
+
+    def test_invalid_duration(self):
+        """
+        Should fail parsing a non-int value for `-d`.
+        :return:
+        """
+
+        with self.assertRaises(SystemExit) as se:
+            parse_args(['-d', 'abce'])

--- a/aws_google_auth/tests/test_args_parser.py
+++ b/aws_google_auth/tests/test_args_parser.py
@@ -77,7 +77,7 @@ class TestPythonFailOnVersion(unittest.TestCase):
 
     def test_ask_and_supply_role(self):
 
-        with self.assertRaises(SystemExit) as se:
+        with self.assertRaises(SystemExit):
             parse_args(['-a', '-r', 'da-role'])
 
     def test_invalid_duration(self):
@@ -86,5 +86,5 @@ class TestPythonFailOnVersion(unittest.TestCase):
         :return:
         """
 
-        with self.assertRaises(SystemExit) as se:
+        with self.assertRaises(SystemExit):
             parse_args(['-d', 'abce'])


### PR DESCRIPTION
Due to the primary entry point for this tool being the args parser, these tests exist to ensure that we can validate this interface and know when its structure changes.

If there are other cases that should be added, please let me know and I'll make sure to add them.