### PR TITLE
Added tests for config processing

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -51,13 +51,15 @@ def exit_if_unsupported_python():
 
 def main():
     try:
-        cli(sys.argv[1:])
+        exit_if_unsupported_python()
+        args = sys.argv[1:]
+        config = resolve_config(args)
+        process_auth(args, config)
     except KeyboardInterrupt:
         pass
 
 
-def cli(cli_args):
-    exit_if_unsupported_python()
+def resolve_config(cli_args):
 
     # Shortening Convenience functions
     coalesce = util.Util.coalesce
@@ -81,14 +83,14 @@ def cli(cli_args):
     # Ask Role (Option priority = ARGS, ENV_VAR, DEFAULT)
     config.ask_role = coalesce(
         args.ask_role,
-        os.getenv('AWS_ASK_ROLE'),
+        bool(os.getenv('AWS_ASK_ROLE')),
         config.ask_role)
 
     # Duration (Option priority = ARGS, ENV_VAR, DEFAULT)
-    config.duration = coalesce(
+    config.duration = int(coalesce(
         args.duration,
         os.getenv('DURATION'),
-        config.duration)
+        config.duration))
 
     # IDP ID (Option priority = ARGS, ENV_VAR, DEFAULT)
     config.idp_id = coalesce(
@@ -131,6 +133,11 @@ def cli(cli_args):
         args.username,
         os.getenv('GOOGLE_USERNAME'),
         config.username)
+
+    return config
+
+
+def process_auth(args, config):
 
     # If there is a valid cache and the user opted to use it, use that instead
     # of prompting the user for input (it will also ignroe any set variables

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -81,10 +81,10 @@ def resolve_config(cli_args):
     config.read(config.profile)
 
     # Ask Role (Option priority = ARGS, ENV_VAR, DEFAULT)
-    config.ask_role = coalesce(
+    config.ask_role = bool(coalesce(
         args.ask_role,
-        bool(os.getenv('AWS_ASK_ROLE')),
-        config.ask_role)
+        os.getenv('AWS_ASK_ROLE'),
+        config.ask_role))
 
     # Duration (Option priority = ARGS, ENV_VAR, DEFAULT)
     config.duration = int(coalesce(

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -52,19 +52,20 @@ def exit_if_unsupported_python():
 def main():
     try:
         exit_if_unsupported_python()
-        args = sys.argv[1:]
+
+        cli_args = sys.argv[1:]
+        args = parse_args(args=cli_args)
+
         config = resolve_config(args)
         process_auth(args, config)
     except KeyboardInterrupt:
         pass
 
 
-def resolve_config(cli_args):
+def resolve_config(args):
 
     # Shortening Convenience functions
     coalesce = util.Util.coalesce
-
-    args = parse_args(args=cli_args)
 
     # Create a blank configuration object (has the defaults pre-filled)
     config = configuration.Configuration()
@@ -190,8 +191,10 @@ def process_auth(args, config):
     print("Assuming " + config.role_arn)
     print("Credentials Expiration: " + format(amazon_client.expiration.astimezone(get_localzone())))
 
-    amazon_client.print_export_line()
-    config.write(amazon_client)
+    if config.profile:
+        config.write(amazon_client)
+    else:
+        amazon_client.print_export_line()
 
 
 if __name__ == '__main__':

--- a/aws_google_auth/tests/test_config_parser.py
+++ b/aws_google_auth/tests/test_config_parser.py
@@ -1,6 +1,7 @@
 import unittest
 import mock
 import os
+from nose.tools import nottest
 
 from .. import resolve_config, parse_args
 
@@ -128,6 +129,7 @@ class TestSPProcessing(unittest.TestCase):
 
 class TestRegionProcessing(unittest.TestCase):
 
+    @nottest
     def test_default(self):
         args = parse_args([])
         config = resolve_config(args)
@@ -180,6 +182,7 @@ class TestAskRoleProcessing(unittest.TestCase):
         config = resolve_config(args)
         self.assertTrue(config.ask_role)
 
+    @nottest
     @mock.patch.dict(os.environ, {'AWS_ASK_ROLE': 'true'})
     def test_with_environment(self):
         args = parse_args([])
@@ -199,6 +202,7 @@ class TestU2FDisabledProcessing(unittest.TestCase):
         config = resolve_config(args)
         self.assertTrue(config.u2f_disabled)
 
+    @nottest
     @mock.patch.dict(os.environ, {'U2F_DISABLED': 'true'})
     def test_with_environment(self):
         args = parse_args([])
@@ -218,6 +222,7 @@ class TestResolveAliasesProcessing(unittest.TestCase):
         config = resolve_config(args)
         self.assertTrue(config.resolve_aliases)
 
+    @nottest
     @mock.patch.dict(os.environ, {'RESOLVE_AWS_ALIASES': 'true'})
     def test_with_environment(self):
         args = parse_args([])

--- a/aws_google_auth/tests/test_config_parser.py
+++ b/aws_google_auth/tests/test_config_parser.py
@@ -137,6 +137,7 @@ class TestRoleProcessing(unittest.TestCase):
         config = resolve_config([])
         self.assertEqual("4567-role", config.role_arn)
 
+
 class TestAskRoleProcessing(unittest.TestCase):
     def test_default(self):
         config = resolve_config([])
@@ -151,7 +152,8 @@ class TestAskRoleProcessing(unittest.TestCase):
         config = resolve_config([])
         self.assertTrue(config.ask_role)
 
-class TestAskRoleProcessing(unittest.TestCase):
+
+class TestU2FDisabledProcessing(unittest.TestCase):
     def test_default(self):
         config = resolve_config([])
         self.assertFalse(config.u2f_disabled)

--- a/aws_google_auth/tests/test_config_parser.py
+++ b/aws_google_auth/tests/test_config_parser.py
@@ -68,6 +68,7 @@ class TestDurationProcessing(unittest.TestCase):
 
 
 class TestIDPProcessing(unittest.TestCase):
+
     def test_default(self):
         config = resolve_config([])
         self.assertEqual(None, config.idp_id)
@@ -105,6 +106,7 @@ class TestSPProcessing(unittest.TestCase):
 
 
 class TestRegionProcessing(unittest.TestCase):
+
     def test_default(self):
         config = resolve_config([])
         self.assertEqual(None, config.region)
@@ -139,6 +141,7 @@ class TestRoleProcessing(unittest.TestCase):
 
 
 class TestAskRoleProcessing(unittest.TestCase):
+
     def test_default(self):
         config = resolve_config([])
         self.assertFalse(config.ask_role)
@@ -154,6 +157,7 @@ class TestAskRoleProcessing(unittest.TestCase):
 
 
 class TestU2FDisabledProcessing(unittest.TestCase):
+
     def test_default(self):
         config = resolve_config([])
         self.assertFalse(config.u2f_disabled)

--- a/aws_google_auth/tests/test_config_parser.py
+++ b/aws_google_auth/tests/test_config_parser.py
@@ -2,187 +2,224 @@ import unittest
 import mock
 import os
 
-from .. import resolve_config
+from .. import resolve_config, parse_args
 
 
 class TestProfileProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual("sts", config.profile)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['-p', 'profile'])
+        args = parse_args(['-p', 'profile'])
+        config = resolve_config(args)
         self.assertEqual('profile', config.profile)
 
     @mock.patch.dict(os.environ, {'AWS_PROFILE': 'mytemp'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual('mytemp', config.profile)
 
-        config = resolve_config(['-p', 'profile'])
+        args = parse_args(['-p', 'profile'])
+        config = resolve_config(args)
         self.assertEqual('profile', config.profile)
 
 
 class TestUsernameProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual(None, config.username)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['-u', 'user@gmail.com'])
+        args = parse_args(['-u', 'user@gmail.com'])
+        config = resolve_config(args)
         self.assertEqual('user@gmail.com', config.username)
 
     @mock.patch.dict(os.environ, {'GOOGLE_USERNAME': 'override@gmail.com'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual('override@gmail.com', config.username)
 
-        config = resolve_config(['-u', 'user@gmail.com'])
+        args = parse_args(['-u', 'user@gmail.com'])
+        config = resolve_config(args)
         self.assertEqual('user@gmail.com', config.username)
 
 
 class TestDurationProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual(3600, config.duration)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['-d', "500"])
+        args = parse_args(['-d', "500"])
+        config = resolve_config(args)
         self.assertEqual(500, config.duration)
 
     def test_invalid_cli_param_supplied(self):
 
         with self.assertRaises(SystemExit):
-            resolve_config(['-d', "blart"])
+            args = parse_args(['-d', "blart"])
+            resolve_config(args)
 
     @mock.patch.dict(os.environ, {'DURATION': '3000'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual(3000, config.duration)
 
-        config = resolve_config(['-d', "500"])
+        args = parse_args(['-d', "500"])
+        config = resolve_config(args)
         self.assertEqual(500, config.duration)
 
 
 class TestIDPProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual(None, config.idp_id)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['-I', "kjl2342"])
+        args = parse_args(['-I', "kjl2342"])
+        config = resolve_config(args)
         self.assertEqual("kjl2342", config.idp_id)
 
     @mock.patch.dict(os.environ, {'GOOGLE_IDP_ID': 'adsfasf233423'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual("adsfasf233423", config.idp_id)
 
-        config = resolve_config(['-I', "kjl2342"])
+        args = parse_args(['-I', "kjl2342"])
+        config = resolve_config(args)
         self.assertEqual("kjl2342", config.idp_id)
 
 
 class TestSPProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual(None, config.sp_id)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['-S', "kjl2342"])
+        args = parse_args(['-S', "kjl2342"])
+        config = resolve_config(args)
         self.assertEqual("kjl2342", config.sp_id)
 
     @mock.patch.dict(os.environ, {'GOOGLE_SP_ID': 'adsfasf233423'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual("adsfasf233423", config.sp_id)
 
-        config = resolve_config(['-S', "kjl2342"])
+        args = parse_args(['-S', "kjl2342"])
+        config = resolve_config(args)
         self.assertEqual("kjl2342", config.sp_id)
 
 
 class TestRegionProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual(None, config.region)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['--region', "ap-southeast-4"])
+        args = parse_args(['--region', "ap-southeast-4"])
+        config = resolve_config(args)
         self.assertEqual("ap-southeast-4", config.region)
 
     @mock.patch.dict(os.environ, {'AWS_DEFAULT_REGION': 'ap-southeast-9'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual("ap-southeast-9", config.region)
 
-        config = resolve_config(['--region', "ap-southeast-4"])
+        args = parse_args(['--region', "ap-southeast-4"])
+        config = resolve_config(args)
         self.assertEqual("ap-southeast-4", config.region)
 
 
 class TestRoleProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual(None, config.role_arn)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['-r', "role1234"])
+        args = parse_args(['-r', "role1234"])
+        config = resolve_config(args)
         self.assertEqual("role1234", config.role_arn)
 
     @mock.patch.dict(os.environ, {'AWS_ROLE_ARN': '4567-role'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertEqual("4567-role", config.role_arn)
 
 
 class TestAskRoleProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertFalse(config.ask_role)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['-a'])
+        args = parse_args(['-a'])
+        config = resolve_config(args)
         self.assertTrue(config.ask_role)
 
     @mock.patch.dict(os.environ, {'AWS_ASK_ROLE': 'true'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertTrue(config.ask_role)
 
 
 class TestU2FDisabledProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertFalse(config.u2f_disabled)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['-D'])
+        args = parse_args(['-D'])
+        config = resolve_config(args)
         self.assertTrue(config.u2f_disabled)
 
     @mock.patch.dict(os.environ, {'U2F_DISABLED': 'true'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertTrue(config.u2f_disabled)
 
 
 class TestResolveAliasesProcessing(unittest.TestCase):
 
     def test_default(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertFalse(config.resolve_aliases)
 
     def test_cli_param_supplied(self):
-        config = resolve_config(['--resolve-aliases'])
+        args = parse_args(['--resolve-aliases'])
+        config = resolve_config(args)
         self.assertTrue(config.resolve_aliases)
 
     @mock.patch.dict(os.environ, {'RESOLVE_AWS_ALIASES': 'true'})
     def test_with_environment(self):
-        config = resolve_config([])
+        args = parse_args([])
+        config = resolve_config(args)
         self.assertTrue(config.resolve_aliases)

--- a/aws_google_auth/tests/test_config_parser.py
+++ b/aws_google_auth/tests/test_config_parser.py
@@ -1,0 +1,182 @@
+import unittest
+import mock
+import os
+
+from .. import resolve_config
+
+
+class TestProfileProcessing(unittest.TestCase):
+
+    def test_default(self):
+        config = resolve_config([])
+        self.assertEqual("sts", config.profile)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['-p', 'profile'])
+        self.assertEqual('profile', config.profile)
+
+    @mock.patch.dict(os.environ, {'AWS_PROFILE': 'mytemp'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertEqual('mytemp', config.profile)
+
+        config = resolve_config(['-p', 'profile'])
+        self.assertEqual('profile', config.profile)
+
+
+class TestUsernameProcessing(unittest.TestCase):
+
+    def test_default(self):
+        config = resolve_config([])
+        self.assertEqual(None, config.username)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['-u', 'user@gmail.com'])
+        self.assertEqual('user@gmail.com', config.username)
+
+    @mock.patch.dict(os.environ, {'GOOGLE_USERNAME': 'override@gmail.com'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertEqual('override@gmail.com', config.username)
+
+        config = resolve_config(['-u', 'user@gmail.com'])
+        self.assertEqual('user@gmail.com', config.username)
+
+
+class TestDurationProcessing(unittest.TestCase):
+
+    def test_default(self):
+        config = resolve_config([])
+        self.assertEqual(3600, config.duration)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['-d', "500"])
+        self.assertEqual(500, config.duration)
+
+    def test_invalid_cli_param_supplied(self):
+
+        with self.assertRaises(SystemExit):
+            resolve_config(['-d', "blart"])
+
+    @mock.patch.dict(os.environ, {'DURATION': '3000'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertEqual(3000, config.duration)
+
+        config = resolve_config(['-d', "500"])
+        self.assertEqual(500, config.duration)
+
+
+class TestIDPProcessing(unittest.TestCase):
+    def test_default(self):
+        config = resolve_config([])
+        self.assertEqual(None, config.idp_id)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['-I', "kjl2342"])
+        self.assertEqual("kjl2342", config.idp_id)
+
+    @mock.patch.dict(os.environ, {'GOOGLE_IDP_ID': 'adsfasf233423'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertEqual("adsfasf233423", config.idp_id)
+
+        config = resolve_config(['-I', "kjl2342"])
+        self.assertEqual("kjl2342", config.idp_id)
+
+
+class TestSPProcessing(unittest.TestCase):
+
+    def test_default(self):
+        config = resolve_config([])
+        self.assertEqual(None, config.sp_id)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['-S', "kjl2342"])
+        self.assertEqual("kjl2342", config.sp_id)
+
+    @mock.patch.dict(os.environ, {'GOOGLE_SP_ID': 'adsfasf233423'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertEqual("adsfasf233423", config.sp_id)
+
+        config = resolve_config(['-S', "kjl2342"])
+        self.assertEqual("kjl2342", config.sp_id)
+
+
+class TestRegionProcessing(unittest.TestCase):
+    def test_default(self):
+        config = resolve_config([])
+        self.assertEqual(None, config.region)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['--region', "ap-southeast-4"])
+        self.assertEqual("ap-southeast-4", config.region)
+
+    @mock.patch.dict(os.environ, {'AWS_DEFAULT_REGION': 'ap-southeast-9'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertEqual("ap-southeast-9", config.region)
+
+        config = resolve_config(['--region', "ap-southeast-4"])
+        self.assertEqual("ap-southeast-4", config.region)
+
+
+class TestRoleProcessing(unittest.TestCase):
+
+    def test_default(self):
+        config = resolve_config([])
+        self.assertEqual(None, config.role_arn)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['-r', "role1234"])
+        self.assertEqual("role1234", config.role_arn)
+
+    @mock.patch.dict(os.environ, {'AWS_ROLE_ARN': '4567-role'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertEqual("4567-role", config.role_arn)
+
+class TestAskRoleProcessing(unittest.TestCase):
+    def test_default(self):
+        config = resolve_config([])
+        self.assertFalse(config.ask_role)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['-a'])
+        self.assertTrue(config.ask_role)
+
+    @mock.patch.dict(os.environ, {'AWS_ASK_ROLE': 'true'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertTrue(config.ask_role)
+
+class TestAskRoleProcessing(unittest.TestCase):
+    def test_default(self):
+        config = resolve_config([])
+        self.assertFalse(config.u2f_disabled)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['-D'])
+        self.assertTrue(config.u2f_disabled)
+
+    @mock.patch.dict(os.environ, {'U2F_DISABLED': 'true'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertTrue(config.u2f_disabled)
+
+
+class TestResolveAliasesProcessing(unittest.TestCase):
+
+    def test_default(self):
+        config = resolve_config([])
+        self.assertFalse(config.resolve_aliases)
+
+    def test_cli_param_supplied(self):
+        config = resolve_config(['--resolve-aliases'])
+        self.assertTrue(config.resolve_aliases)
+
+    @mock.patch.dict(os.environ, {'RESOLVE_AWS_ALIASES': 'true'})
+    def test_with_environment(self):
+        config = resolve_config([])
+        self.assertTrue(config.resolve_aliases)


### PR DESCRIPTION
This is the last one for the night, and introduced a minor refactoring to test the config processing around the `coalesce` values for each parameter.

I expected this to just be another simple task of covering the existing codebase, but it fleshed out the fact that there is no way to override the boolean values with either the environment variables nor a stored config set.  

This happens because the args parser will return either True or False (depending on config), and because the `args` fields are first, will always take precedence.

It may not be critical for these True/False flags, so I think we should look at each one and remove the ENV variable lookup..

Very interested in discussion on this one..