### PR TITLE
Introduced new Exception to remove stack trace noise 

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -10,6 +10,8 @@ import argparse
 import getpass
 import os
 import sys
+
+from google import ExpectedGoogleException
 from tzlocal import get_localzone
 
 
@@ -52,6 +54,9 @@ def exit_if_unsupported_python():
 def main():
     try:
         cli(sys.argv[1:])
+    except ExpectedGoogleException as ex:
+        print ex.message
+        sys.exit(1)
     except KeyboardInterrupt:
         pass
 

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -55,7 +55,7 @@ def main():
     try:
         cli(sys.argv[1:])
     except ExpectedGoogleException as ex:
-        print ex.message
+        print(ex.message)
         sys.exit(1)
     except KeyboardInterrupt:
         pass

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -11,7 +11,6 @@ import getpass
 import os
 import sys
 
-from google import ExpectedGoogleException
 from tzlocal import get_localzone
 
 
@@ -54,7 +53,7 @@ def exit_if_unsupported_python():
 def main():
     try:
         cli(sys.argv[1:])
-    except ExpectedGoogleException as ex:
+    except google.ExpectedGoogleException as ex:
         print(ex.message)
         sys.exit(1)
     except KeyboardInterrupt:

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -24,6 +24,12 @@ except ImportError:
           "methods can still continue.")
 
 
+class ExpectedGoogleException(Exception):
+
+    def __init__(self, *args):
+        super(ExpectedGoogleException, self).__init__(*args)
+
+
 class Google:
     def __init__(self, config):
         """The Google object holds authentication state
@@ -45,11 +51,41 @@ class Google:
     def login_url(self):
         return "https://accounts.google.com/o/saml2/initsso?idpid={}&spid={}&forceauthn=false".format(self.config.idp_id, self.config.sp_id)
 
+    @staticmethod
+    def check_for_failure(sess):
+
+        if isinstance(sess.reason, bytes):
+            # We attempt to decode utf-8 first because some servers
+            # choose to localize their reason strings. If the string
+            # isn't utf-8, we fall back to iso-8859-1 for all other
+            # encodings. (See PR #3538)
+            try:
+                reason = sess.reason.decode('utf-8')
+            except UnicodeDecodeError:
+                reason = sess.reason.decode('iso-8859-1')
+        else:
+            reason = sess.reason
+
+        if sess.status_code == 403:
+            raise ExpectedGoogleException(u'%s accessing %s' % (reason, sess.url))
+
+        sess.raise_for_status()
+
+    @staticmethod
+    def parse_error_message(sess):
+        response_page = BeautifulSoup(sess.text, 'html.parser')
+        error = response_page.find('span', {'id': 'errorMsg'})
+
+        if error is None:
+            return None
+        else:
+            return error.text
+
     def do_login(self):
         self.session = requests.Session()
         self.session.headers['User-Agent'] = "AWS Sign-in/{} (Cevo aws-google-auth)".format(self.version)
         sess = self.session.get(self.login_url)
-        sess.raise_for_status()
+        self.check_for_failure(sess)
 
         # Collect information from the page source
         first_page = BeautifulSoup(sess.text, 'html.parser')
@@ -92,7 +128,7 @@ class Google:
 
         # POST to account login info page, to collect profile and session info
         sess = self.session.post(account_login_url, data=payload)
-        sess.raise_for_status()
+        self.check_for_failure(sess)
         self.session.headers['Referer'] = sess.url
 
         # Collect ProfileInformation, SessionState, signIn, and Password Challenge URL
@@ -111,7 +147,7 @@ class Google:
 
         # POST to Authenticate Password
         sess = self.session.post(passwd_challenge_url, data=payload)
-        sess.raise_for_status()
+        self.check_for_failure(sess)
         response_page = BeautifulSoup(sess.text, 'html.parser')
         error = response_page.find(class_='error-msg')
         cap = response_page.find('input', {'name': 'logincaptcha'})
@@ -120,16 +156,21 @@ class Google:
         # There could also sometimes be a Captcha, which means Google thinks you,
         # or someone using the same outbound IP address as you, is a bot.
         if error is not None:
-            raise ValueError('Invalid username or password')
+            raise ExpectedGoogleException('Invalid username or password')
 
         if cap is not None:
-            raise ValueError('Captcha Required. Manually Login to remove this.')
+            raise ExpectedGoogleException('Captcha Required. Manually Login to remove this.')
 
         self.session.headers['Referer'] = sess.url
 
         # Was there an MFA challenge?
         if "challenge/totp/" in sess.url:
-            sess = self.handle_totp(sess)
+            error_msg = ""
+            while error_msg is not None:
+                sess = self.handle_totp(sess)
+                error_msg = self.parse_error_message(sess)
+                if error_msg is not None:
+                    print error_msg
         elif "challenge/ipp/" in sess.url:
             sess = self.handle_sms(sess)
         elif "challenge/az/" in sess.url:
@@ -186,7 +227,7 @@ class Google:
 
         # If we exceed the number of attempts, raise an error and let the program exit.
         if auth_response is None:
-            raise RuntimeError("No U2F device found. Please check your setup.")
+            raise ExpectedGoogleException("No U2F device found. Please check your setup.")
 
         payload = {
             'challengeId': response_page.find('input', {'name': 'challengeId'}).get('value'),
@@ -204,7 +245,7 @@ class Google:
         }
 
         sess = self.session.post(challenge_url, data=payload)
-        sess.raise_for_status()
+        self.check_for_failure(sess)
 
         return sess
 
@@ -233,7 +274,7 @@ class Google:
 
         # Submit IPP (SMS code)
         sess = self.session.post(challenge_url, data=payload)
-        sess.raise_for_status()
+        self.check_for_failure(sess)
 
         return sess
 
@@ -271,7 +312,7 @@ class Google:
         }
 
         sess = self.session.post(challenge_url, data=payload)
-        sess.raise_for_status()
+        self.check_for_failure(sess)
 
         return sess
 
@@ -306,6 +347,6 @@ class Google:
 
         # Submit TOTP
         sess = self.session.post(challenge_url, data=payload)
-        sess.raise_for_status()
+        self.check_for_failure(sess)
 
         return sess

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -170,7 +170,7 @@ class Google:
                 sess = self.handle_totp(sess)
                 error_msg = self.parse_error_message(sess)
                 if error_msg is not None:
-                    print error_msg
+                    print(error_msg)
         elif "challenge/ipp/" in sess.url:
             sess = self.handle_sms(sess)
         elif "challenge/az/" in sess.url:


### PR DESCRIPTION
Introduced new Exception to remove stack trace noise from known failures.

Currently invalid email or password results in:

```
Traceback (most recent call last):
  File "/Users/steve.mactaggart/development/cevo/aws-google-auth/.venv/bin/aws-google-auth", line 11, in <module>
    load_entry_point('aws-google-auth==0.0.20', 'console_scripts', 'aws-google-auth')()
  File "/Users/steve.mactaggart/development/cevo/aws-google-auth/.venv/lib/python2.7/site-packages/aws_google_auth-0.0.20-py2.7.egg/aws_google_auth/__init__.py", line 54, in main
    cli(sys.argv[1:])
  File "/Users/steve.mactaggart/development/cevo/aws-google-auth/.venv/lib/python2.7/site-packages/aws_google_auth-0.0.20-py2.7.egg/aws_google_auth/__init__.py", line 159, in cli
    google_client.do_login()
  File "/Users/steve.mactaggart/development/cevo/aws-google-auth/.venv/lib/python2.7/site-packages/aws_google_auth-0.0.20-py2.7.egg/aws_google_auth/google.py", line 123, in do_login
    raise ValueError('Invalid username or password')
ValueError: Invalid username or password
```

With this change you'll just see:

```
Invalid username or password
```

For known error scenarios, `raise ExpectedGoogleException("Error message")` to notify the user of the error but not show a scary stack trace.

As part of investigating failure scenarios, I also located that invalid MFA tokens would look like an internal tool issue.  If you enter an invalid MFA you'll see an error like:

```
MFA token: blart
Traceback (most recent call last):
  File "/Users/steve.mactaggart/development/cevo/aws-google-auth/.venv/bin/aws-google-auth", line 11, in <module>
    load_entry_point('aws-google-auth==0.0.20', 'console_scripts', 'aws-google-auth')()
  File "/Users/steve.mactaggart/development/cevo/aws-google-auth/.venv/lib/python2.7/site-packages/aws_google_auth-0.0.20-py2.7.egg/aws_google_auth/__init__.py", line 54, in main
    cli(sys.argv[1:])
  File "/Users/steve.mactaggart/development/cevo/aws-google-auth/.venv/lib/python2.7/site-packages/aws_google_auth-0.0.20-py2.7.egg/aws_google_auth/__init__.py", line 160, in cli
    saml_xml = google_client.parse_saml()
  File "/Users/steve.mactaggart/development/cevo/aws-google-auth/.venv/lib/python2.7/site-packages/aws_google_auth-0.0.20-py2.7.egg/aws_google_auth/google.py", line 158, in parse_saml
    raise RuntimeError('Could not find SAML response, check your credentials')
RuntimeError: Could not find SAML response, check your credentials
```

This change includes detection of that error message, shows it to the user and re-asks for the MFA.

Need a test scenario to validate this need for the other auth methods.