### PR TITLE
Fixes problem with printing ExceptionGoogleException message

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -62,7 +62,7 @@ def cli(cli_args):
         config = resolve_config(args)
         process_auth(args, config)
     except google.ExpectedGoogleException as ex:
-        print(ex.message)
+        print(ex)
         sys.exit(1)
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
Print of the message contained in the google.ExpectedGoogleException was looking for a variable named `message` which did not exist, which resulted in throwing an additional exception. 

```
Google Password:
Traceback (most recent call last):
  File "/build/aws_google_auth/__init__.py", line 63, in cli
    process_auth(args, config)
  File "/build/aws_google_auth/__init__.py", line 184, in process_auth
    google_client.do_login()
  File "/build/aws_google_auth/google.py", line 161, in do_login
    raise ExpectedGoogleException('Invalid username or password')
aws_google_auth.google.ExpectedGoogleException: Invalid username or password

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/aws-google-auth", line 9, in <module>
    load_entry_point('aws-google-auth', 'console_scripts', 'aws-google-auth')()
  File "/build/aws_google_auth/__init__.py", line 224, in main
    cli(cli_args)
  File "/build/aws_google_auth/__init__.py", line 65, in cli
    print(ex.message)
AttributeError: 'ExpectedGoogleException' object has no attribute 'message'
```

with the fix in this PR:
```
Google Password:
Invalid username or password
```