### PR TITLE
prevent usage of keyring in test_process_auth_dont_resolve_alias

### DIFF
--- a/aws_google_auth/tests/test_init.py
+++ b/aws_google_auth/tests/test_init.py
@@ -240,6 +240,7 @@ class TestInit(unittest.TestCase):
         mock_config.idp_id = None
         mock_config.sp_id = None
         mock_config.return_value = None
+        mock_config.keyring = False
 
         mock_amazon_client = Mock()
         mock_google_client = Mock()


### PR DESCRIPTION
During testing for #86 there was a failing test ([`test_process_auth_dont_resolve_alias`](https://travis-ci.org/cevoaustralia/aws-google-auth/jobs/409949606)) only on my local machine.

The test was failing (remotely) because the `Google Password:` prompt was presented when not expected.

Test were failing only on Travis, and not on my laptop, which was unexpected. Also, test where failing using the `origin/master` branch ( in my fork ) up to date with `upstream/master`, which was unexpected because Travis build for upstream master are green. This shown that the problem is not related to the PR #86.

So:
- test **failing** on local machine for `origin/master` up to date with `upstream/master`
- test **not** failing on Travis
- test **not** failing on local machine the first time
- test **failing** on local machine after the first time

This was happening because that test was writing in the my laptop keyring :sweat: : at first run the `pass` value was saved in the keyring, making all successive test run failing.
The `Google Password` prompt, which was expected, was not run after the first time, because the value was being retrieved from keyring.

This PR force the `config` mock `keyring` to `False`, in order to never use the keyring: this way the prompt is always present and tests are happy.