### PR TITLE
Always display CAPTCHA url

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -319,14 +319,16 @@ class Google:
         captcha_logintoken_audio = captcha_container.find('input', {'name': 'logintoken_audio'}).get('value')
         captcha_url_audio = captcha_container.find('input', {'name': 'url_audio'}).get('value')
 
-        # Try to open the image for the user automatically, but if that fails for
-        # any reason, just display the URL for the user to visit.
+        print("Please visit the following URL to view your CAPTCHA: {}".format(captcha_url))
+
+        # Try to open the image for the user automatically, won't work when
+        # running from Docker.
         try:
             with requests.get(captcha_url) as url:
                 with io.BytesIO(url.content) as f:
                     Image.open(f).show()
         except Exception:
-            print("Please visit the following URL to view your CAPTCHA: {}".format(captcha_url))
+            pass
 
         try:
             captcha_input = raw_input("Captcha (case insensitive): ") or None


### PR DESCRIPTION
See #111 

I think #105 still needs to be implemented as we probably shouldn't call `xv` in an environment where it won't be available, but even with that I believe it's better to always show the CAPTCHA url, as it solves two things:
- PIL `.show()` not being very reliable
- Usability issue: if you close the captcha image window by accident you can't reopen it, you have to restart the sign-on process again