### PR TITLE
Catch exception raised when empty string is given when selecting role

### DIFF
--- a/aws_google_auth/util.py
+++ b/aws_google_auth/util.py
@@ -44,7 +44,7 @@ class Util:
 
                 try:
                     return list(ordered_roles.items())[int(choice) - 1]
-                except IndexError:
+                except (IndexError, ValueError):
                     print("Invalid choice, try again.")
         else:
             while True:
@@ -56,7 +56,7 @@ class Util:
 
                 try:
                     return list(roles.items())[int(choice) - 1]
-                except IndexError:
+                except (IndexError, ValueError):
                     print("Invalid choice, try again.")
 
     @staticmethod


### PR DESCRIPTION
Kind of related to #93 .

When presented with the list of roles available to assume, if the user doesn't enter anything on the field it just crashes, as it doesn't have any default value to select.

I'm not 100% on auto-selecting a role, but this change just avoids the library to crash, prompting the user to enter a valid input.