### PR TITLE
add --quiet option

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -29,6 +29,7 @@ def parse_args(args):
     parser.add_argument('-d', '--duration', type=int, help='Credential duration ($DURATION)')
     parser.add_argument('-p', '--profile', help='AWS profile (defaults to value of $AWS_PROFILE, then falls back to \'sts\')')
     parser.add_argument('-D', '--disable-u2f', action='store_true', help='Disable U2F functionality.')
+    parser.add_argument('-q', '--quiet', action='store_true', help='Quiet output')
     parser.add_argument('--no-cache', dest="saml_cache", action='store_false', help='Do not cache the SAML Assertion.')
     parser.add_argument('--print-creds', action='store_true', help='Print Credentials.')
     parser.add_argument('--resolve-aliases', action='store_true', help='Resolve AWS account aliases.')
@@ -152,6 +153,11 @@ def resolve_config(args):
         args.print_creds,
         config.print_creds)
 
+    # Quiet
+    config.quiet = coalesce(
+        args.quiet,
+        config.quiet)
+
     return config
 
 
@@ -216,9 +222,9 @@ def process_auth(args, config):
             config.role_arn, config.provider = util.Util.pick_a_role(roles, aliases)
         else:
             config.role_arn, config.provider = util.Util.pick_a_role(roles)
-
-    print("Assuming " + config.role_arn)
-    print("Credentials Expiration: " + format(amazon_client.expiration.astimezone(get_localzone())))
+    if not config.quiet:
+        print("Assuming " + config.role_arn)
+        print("Credentials Expiration: " + format(amazon_client.expiration.astimezone(get_localzone())))
 
     if config.print_creds:
         amazon_client.print_export_line()

--- a/aws_google_auth/configuration.py
+++ b/aws_google_auth/configuration.py
@@ -34,6 +34,7 @@ class Configuration(object):
         self.resolve_aliases = False
         self.username = None
         self.print_creds = False
+        self.quiet = False
 
     # For the "~/.aws/config" file, we use the format "[profile testing]"
     # for the 'testing' profile. The credential file will just be "[testing]"
@@ -131,6 +132,9 @@ class Configuration(object):
 
         # u2f_disabled
         assert (self.u2f_disabled.__class__ is bool), "Expected u2f_disabled to be a boolean. Got {}.".format(self.u2f_disabled.__class__)
+
+        # quiet
+        assert (self.quiet.__class__ is bool), "Expected quiet to be a boolean. Got {}.".format(self.quiet.__class__)
 
     # Write the configuration (and credentials) out to disk. This allows for
     # regular AWS tooling (aws cli and boto) to use the credentials in the

--- a/aws_google_auth/tests/test_args_parser.py
+++ b/aws_google_auth/tests/test_args_parser.py
@@ -29,12 +29,13 @@ class TestPythonFailOnVersion(unittest.TestCase):
         self.assertEqual(parser.region, None)
         self.assertEqual(parser.role_arn, None)
         self.assertEqual(parser.username, None)
+        self.assertEqual(parser.quiet, False)
 
         self.assertFalse(parser.save_failure_html)
 
         # Assert the size of the parameter so that new parameters trigger a review of this function
         # and the appropriate defaults are added here to track backwards compatibility in the future.
-        self.assertEqual(len(vars(parser)), 14)
+        self.assertEqual(len(vars(parser)), 15)
 
     def test_username(self):
 

--- a/aws_google_auth/tests/test_init.py
+++ b/aws_google_auth/tests/test_init.py
@@ -57,7 +57,8 @@ class TestInit(unittest.TestCase):
                                          saml_cache=True,
                                          sp_id=None,
                                          print_creds=False,
-                                         username=None))
+                                         username=None,
+                                         quiet=False))
                           ],
                          resolve_config.mock_calls)
 
@@ -74,7 +75,8 @@ class TestInit(unittest.TestCase):
                                          saml_cache=True,
                                          sp_id=None,
                                          print_creds=False,
-                                         username=None),
+                                         username=None,
+                                         quiet=False),
                                mock_config)
                           ],
                          process_auth.mock_calls)


### PR DESCRIPTION
Hello there! I mentioned the idea of adding a `--quiet` flag in this github issue: https://github.com/cevoaustralia/aws-google-auth/issues/123. @stevemac007 seemed into so I went ahead and gave it a shot! Ran all tests locally with `pytest` and they all pass.

The only thing I'm trying to figure out is how to quiet the message `Failed to import U2F libraries...` [here](https://github.com/cevoaustralia/aws-google-auth/blob/master/aws_google_auth/google.py#L25). Since it's imported before the `Google` class is instantiated, we don't have access to the `config` object. One option would be to put the import statement in the `__init__` function for the `Google` class, but that seems weird to me? idk. Let me know what you think about that. Thank you! I'm also not sure this message is needed since this package explicitly supports using U2F or not, and gives users options for how to install with or without. Open to any ideas tho!