### PR TITLE
Resolve issue 128 - yubikey auth flow broken by google page update

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -415,7 +415,6 @@ class Google:
         while True:
             try:
                 auth_response_dict = u2f.u2f_auth(u2f_challenges, facet)
-                #auth_response_dict['sessionId'] = ''
                 auth_response = json.dumps(auth_response_dict)
                 break
             except RuntimeWarning:

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -406,8 +406,11 @@ class Google:
         keyHandle = self.find_key_handle(keyHandleJsonPayload, base64.urlsafe_b64encode(base64.b64decode(challenges_txt)))
         appId = self.find_app_id(str(keyHandleJsonPayload))
 
+        # txt sent for signing needs to be base64 url encode
+        # we also have to remove any base64 padding because including including it will prevent google accepting the auth response
+        challenges_txt_encode_pad_removed = base64.urlsafe_b64encode(base64.b64decode(challenges_txt)).strip('=')
         u2f_challenges = []
-        u2f_challenges.append({'version': 'U2F_V2', 'challenge': base64.urlsafe_b64encode(base64.b64decode(challenges_txt)), 'appId': appId, 'keyHandle': keyHandle})
+        u2f_challenges.append({'version': 'U2F_V2', 'challenge': challenges_txt_encode_pad_removed, 'appId': appId, 'keyHandle': keyHandle})
 
         # Prompt the user up to attempts_remaining times to insert their U2F device.
         attempts_remaining = 5

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -147,7 +147,7 @@ class Google:
                     return Google.find_key_handle(item, challengeTxt)
                 elif typeValue == int or typeValue == bool:  # ints bools etc we don't care
                     continue
-                else:  #  we went a string or unicode here (python 3.x lost unicode global)
+                else:  # we went a string or unicode here (python 3.x lost unicode global)
                     try:  # keyHandle string will be base64 encoded -
                         # if its not an exception is thrown and we continue as its not the string we're after
                         base64UrlEncoded = base64.urlsafe_b64encode(base64.b64decode(item))
@@ -155,6 +155,7 @@ class Google:
                             return base64UrlEncoded
                     except:
                         pass
+
     @staticmethod
     def find_app_id(inputString):
         try:

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -7,6 +7,7 @@ import io
 import json
 import logging
 import os
+import re
 import sys
 
 import requests
@@ -131,6 +132,39 @@ class Google:
             return None
         else:
             return error.text
+
+    @staticmethod
+    def find_key_handle(input, challengeTxt):
+        typeOfInput = type(input)
+        if typeOfInput == dict: # parse down a dict
+            for item in input:
+                return Google.find_key_handle(input[item], challengeTxt)
+        elif typeOfInput == list: # looks like we've hit an array - iterate it
+            array = list(filter(None, input)) # remove any None type objects from the array
+            for item in array:
+                typeValue = type(item)
+                if typeValue == list: # another array - recursive call
+                    return Google.find_key_handle(item, challengeTxt)
+                elif typeValue == unicode: # found a string value - maybe what we're looking for
+                    try: # keyHandle string will be base64 encoded -
+                        # if its not an exception is thrown and we continue as its not the string we're after
+                        base64UrlEncoded = base64.urlsafe_b64encode(base64.b64decode(item))
+                        if base64UrlEncoded != challengeTxt: # make sure its not the challengeTxt - if it not return it
+                            return base64UrlEncoded
+                    except:
+                        pass
+                else: # ints bools etc we don't care
+                    continue
+
+    @staticmethod
+    def find_app_id(inputString):
+        try:
+            searchResult = re.search('"appid":"[a-z://.-_]+"',inputString).group()
+            searchObject = json.loads('{' + searchResult + '}')
+            return str(searchObject['appid'])
+        except:
+            logging.exception('Was unable to find appid value in googles SAML page')
+            sys.exit(1)
 
     def do_login(self):
         self.session = requests.Session()
@@ -357,26 +391,32 @@ class Google:
     def handle_sk(self, sess):
         response_page = BeautifulSoup(sess.text, 'html.parser')
         challenge_url = sess.url.split("?")[0]
-
         challenges_txt = response_page.find('input', {
             'name': "id-challenge"
         }).get('value')
-        challenges = json.loads(challenges_txt)
 
         facet_url = urllib_parse.urlparse(challenge_url)
         facet = facet_url.scheme + "://" + facet_url.netloc
-        app_id = challenges["appId"]
+
+        keyHandleJSField = response_page.find('div',{'jsname': 'C0oDBd'}).get('data-challenge-ui')
+        startJSONPosition = keyHandleJSField.find('{')
+        endJSONPosition = keyHandleJSField.rfind('}')
+        keyHandleJsonPayload = json.loads(keyHandleJSField[startJSONPosition:endJSONPosition+1])
+
+        keyHandle = self.find_key_handle(keyHandleJsonPayload, base64.urlsafe_b64encode(base64.b64decode(challenges_txt)))
+        appId = self.find_app_id(str(keyHandleJsonPayload))
+
         u2f_challenges = []
-        for c in challenges["challenges"]:
-            c["appId"] = app_id
-            u2f_challenges.append(c)
+        u2f_challenges.append({'version': 'U2F_V2', 'challenge': base64.urlsafe_b64encode(base64.b64decode(challenges_txt)), 'appId': appId, 'keyHandle': keyHandle})
 
         # Prompt the user up to attempts_remaining times to insert their U2F device.
         attempts_remaining = 5
         auth_response = None
         while True:
             try:
-                auth_response = json.dumps(u2f.u2f_auth(u2f_challenges, facet))
+                auth_response_dict = u2f.u2f_auth(u2f_challenges, facet)
+                #auth_response_dict['sessionId'] = ''
+                auth_response = json.dumps(auth_response_dict)
                 break
             except RuntimeWarning:
                 logging.error("No U2F device found. %d attempts remaining",
@@ -403,8 +443,7 @@ class Google:
             response_page.find('input', {
                 'name': 'challengeType'
             }).get('value'),
-            'continue':
-            response_page.find('input', {
+            'continue': response_page.find('input', {
                 'name': 'continue'
             }).get('value'),
             'scc':
@@ -419,10 +458,7 @@ class Google:
             response_page.find('input', {
                 'name': 'checkedDomains'
             }).get('value'),
-            'pstMsg':
-            response_page.find('input', {
-                'name': 'pstMsg'
-            }).get('value'),
+            'pstMsg': '1',
             'TL':
             response_page.find('input', {
                 'name': 'TL'

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -136,30 +136,30 @@ class Google:
     @staticmethod
     def find_key_handle(input, challengeTxt):
         typeOfInput = type(input)
-        if typeOfInput == dict: # parse down a dict
+        if typeOfInput == dict:  # parse down a dict
             for item in input:
                 return Google.find_key_handle(input[item], challengeTxt)
-        elif typeOfInput == list: # looks like we've hit an array - iterate it
-            array = list(filter(None, input)) # remove any None type objects from the array
+        elif typeOfInput == list:  # looks like we've hit an array - iterate it
+            array = list(filter(None, input))  # remove any None type objects from the array
             for item in array:
                 typeValue = type(item)
-                if typeValue == list: # another array - recursive call
+                if typeValue == list:  # another array - recursive call
                     return Google.find_key_handle(item, challengeTxt)
-                elif typeValue == unicode: # found a string value - maybe what we're looking for
-                    try: # keyHandle string will be base64 encoded -
+                elif typeValue == unicode:  # found a string value - maybe what we're looking for
+                    try:  # keyHandle string will be base64 encoded -
                         # if its not an exception is thrown and we continue as its not the string we're after
                         base64UrlEncoded = base64.urlsafe_b64encode(base64.b64decode(item))
-                        if base64UrlEncoded != challengeTxt: # make sure its not the challengeTxt - if it not return it
+                        if base64UrlEncoded != challengeTxt:  # make sure its not the challengeTxt - if it not return it
                             return base64UrlEncoded
                     except:
                         pass
-                else: # ints bools etc we don't care
+                else:  # ints bools etc we don't care
                     continue
 
     @staticmethod
     def find_app_id(inputString):
         try:
-            searchResult = re.search('"appid":"[a-z://.-_]+"',inputString).group()
+            searchResult = re.search('"appid":"[a-z://.-_]+"', inputString).group()
             searchObject = json.loads('{' + searchResult + '}')
             return str(searchObject['appid'])
         except:
@@ -398,10 +398,10 @@ class Google:
         facet_url = urllib_parse.urlparse(challenge_url)
         facet = facet_url.scheme + "://" + facet_url.netloc
 
-        keyHandleJSField = response_page.find('div',{'jsname': 'C0oDBd'}).get('data-challenge-ui')
+        keyHandleJSField = response_page.find('div', {'jsname': 'C0oDBd'}).get('data-challenge-ui')
         startJSONPosition = keyHandleJSField.find('{')
         endJSONPosition = keyHandleJSField.rfind('}')
-        keyHandleJsonPayload = json.loads(keyHandleJSField[startJSONPosition:endJSONPosition+1])
+        keyHandleJsonPayload = json.loads(keyHandleJSField[startJSONPosition:endJSONPosition + 1])
 
         keyHandle = self.find_key_handle(keyHandleJsonPayload, base64.urlsafe_b64encode(base64.b64decode(challenges_txt)))
         appId = self.find_app_id(str(keyHandleJsonPayload))

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -145,7 +145,9 @@ class Google:
                 typeValue = type(item)
                 if typeValue == list:  # another array - recursive call
                     return Google.find_key_handle(item, challengeTxt)
-                elif typeValue == unicode:  # found a string value - maybe what we're looking for
+                elif typeValue == int or typeValue == bool:  # ints bools etc we don't care
+                    continue
+                else:  #  we went a string or unicode here (python 3.x lost unicode global)
                     try:  # keyHandle string will be base64 encoded -
                         # if its not an exception is thrown and we continue as its not the string we're after
                         base64UrlEncoded = base64.urlsafe_b64encode(base64.b64decode(item))
@@ -153,9 +155,6 @@ class Google:
                             return base64UrlEncoded
                     except:
                         pass
-                else:  # ints bools etc we don't care
-                    continue
-
     @staticmethod
     def find_app_id(inputString):
         try:

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -138,7 +138,10 @@ class Google:
         typeOfInput = type(input)
         if typeOfInput == dict:  # parse down a dict
             for item in input:
-                return Google.find_key_handle(input[item], challengeTxt)
+                rvalue = Google.find_key_handle(input[item], challengeTxt)
+                if rvalue is not None:
+                    return rvalue
+
         elif typeOfInput == list:  # looks like we've hit an array - iterate it
             array = list(filter(None, input))  # remove any None type objects from the array
             for item in array:
@@ -408,9 +411,10 @@ class Google:
 
         # txt sent for signing needs to be base64 url encode
         # we also have to remove any base64 padding because including including it will prevent google accepting the auth response
-        challenges_txt_encode_pad_removed = base64.urlsafe_b64encode(base64.b64decode(challenges_txt)).strip('=')
+        challenges_txt_encode_pad_removed = base64.urlsafe_b64encode(base64.b64decode(challenges_txt)).strip('='.encode())
+
         u2f_challenges = []
-        u2f_challenges.append({'version': 'U2F_V2', 'challenge': challenges_txt_encode_pad_removed, 'appId': appId, 'keyHandle': keyHandle})
+        u2f_challenges.append({'version': 'U2F_V2', 'challenge': challenges_txt_encode_pad_removed.decode(), 'appId': appId, 'keyHandle': keyHandle.decode()})
 
         # Prompt the user up to attempts_remaining times to insert their U2F device.
         attempts_remaining = 5


### PR DESCRIPTION
This makes an attempt to resolve issue https://github.com/cevoaustralia/aws-google-auth/issues/128
Works for me with a single yubikey on my google corporate account.

Google changed the id-challenge field to contain just the challenge txt, they include the other information now hidden away inside a div tag further down in a json like object that contains a bunch of nulls. 
They also provide some of the data in base64 now but their api expects base64 url encoded on some of the fields, despite all that being base64'd itself. 

This PR has resolved the issue for us, I'd be very keen to hear from others if this works for them. 
Comments, feedback etc welcome, I'm not exactly a python expert so any points there welcome too :-)