### PR TITLE
Improvement: Add Process-Creds option for use by AWS CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,39 +115,44 @@ Usage
 
     $ aws-google-auth -h
     usage: aws-google-auth [-h] [-u USERNAME] [-I IDP_ID] [-S SP_ID] [-R REGION]
-                           [-d DURATION] [-p PROFILE] [-D] [-q] [--no-cache]
-                           [--print-creds] [--resolve-aliases]
-                           [--save-failure-html] [-a | -r ROLE_ARN] [-k] [-V]
+                        [-d DURATION] [-p PROFILE] [-D] [-q] [--no-cache]
+                        [--resolve-aliases] [--save-failure-html]
+                        [--print-creds | --process-creds] [-a | -r ROLE_ARN]
+                        [-k] [-l {debug,info,warn}] [-V]
 
     Acquire temporary AWS credentials via Google SSO
 
     optional arguments:
-      -h, --help            show this help message and exit
-      -u USERNAME, --username USERNAME
+    -h, --help            show this help message and exit
+    -u USERNAME, --username USERNAME
                             Google Apps username ($GOOGLE_USERNAME)
-      -I IDP_ID, --idp-id IDP_ID
+    -I IDP_ID, --idp-id IDP_ID
                             Google SSO IDP identifier ($GOOGLE_IDP_ID)
-      -S SP_ID, --sp-id SP_ID
+    -S SP_ID, --sp-id SP_ID
                             Google SSO SP identifier ($GOOGLE_SP_ID)
-      -R REGION, --region REGION
+    -R REGION, --region REGION
                             AWS region endpoint ($AWS_DEFAULT_REGION)
-      -d DURATION, --duration DURATION
+    -d DURATION, --duration DURATION
                             Credential duration ($DURATION)
-      -p PROFILE, --profile PROFILE
+    -p PROFILE, --profile PROFILE
                             AWS profile (defaults to value of $AWS_PROFILE, then
                             falls back to 'sts')
-      -D, --disable-u2f     Disable U2F functionality.
-      -q, --quiet           Quiet output
-      --no-cache            Do not cache the SAML Assertion.
-      --print-creds         Print Credentials.
-      --resolve-aliases     Resolve AWS account aliases.
-      --save-failure-html   Write HTML failure responses to file for
+    -D, --disable-u2f     Disable U2F functionality.
+    -q, --quiet           Quiet output
+    --no-cache            Do not cache the SAML Assertion.
+    --resolve-aliases     Resolve AWS account aliases.
+    --save-failure-html   Write HTML failure responses to file for
                             troubleshooting.
-      -a, --ask-role        Set true to always pick the role
-      -r ROLE_ARN, --role-arn ROLE_ARN
+    --print-creds         Print Credentials.
+    --process-creds       Print Credentials in JSON format for AWS CLI
+                            credential_process directive.
+    -a, --ask-role        Set true to always pick the role
+    -r ROLE_ARN, --role-arn ROLE_ARN
                             The ARN of the role to assume
-      -k, --keyring         Use keyring for storing the password.
-      -V, --version         show program's version number and exit
+    -k, --keyring         Use keyring for storing the password.
+    -l {debug,info,warn}, --log {debug,info,warn}
+                            Select log level (default: warn)
+    -V, --version         show program's version number and exit
 
 
 **Note** that if you want longer than the default 3600 seconds (1 hour)
@@ -162,6 +167,29 @@ Native Python
 2. You will be prompted to supply each parameter
 
 *Note* You can skip prompts by either passing parameters to the command, or setting the specified Environment variables.
+
+AWS CLI Credential Process
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*aws-google-auth* can be added as a ``credential_process`` to the AWS CLI
+configuration files, so that it is invoked as needed.
+
+The first time setup requires supplying information that
+will populate an AWS CLI profile.
+
+1. Execute ``aws-google-auth --profile [google]``,
+   replacing ``[google]`` with the profile name you want.
+2. You will be prompted to supply each parameter
+3. Add the following to the profile in ``~/.aws/config``,
+   ``credential_process = aws-google-auth --profile [google]  --process-creds``
+
+For future sessions, the AWS CLI will call *aws-google-auth* directly,
+by either:
+
+- Setting the ``AWS_PROFILE`` environment variable, or
+- Using the ``--profile`` option on the ``aws`` command.
+  (i.e. ``aws --profile [google] sts get-caller-identity``).
+
 
 Via Docker
 ~~~~~~~~~~~~~

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -74,7 +74,7 @@ def cli(cli_args):
         config = resolve_config(args)
         process_auth(args, config)
     except google.ExpectedGoogleException as ex:
-        print(ex)
+        print(ex, file=util.Util.get_output())
         sys.exit(1)
     except KeyboardInterrupt:
         pass
@@ -178,6 +178,7 @@ def resolve_config(args):
 
 def process_auth(args, config):
     # Set up logging
+    logging.basicConfig(stream=util.Util.get_output())
     logging.getLogger().setLevel(getattr(logging, args.log_level.upper(), None))
 
     # If there is a valid cache and the user opted to use it, use that instead
@@ -247,8 +248,8 @@ def process_auth(args, config):
         else:
             config.role_arn, config.provider = util.Util.pick_a_role(roles)
     if not config.quiet:
-        print("Assuming " + config.role_arn)
-        print("Credentials Expiration: " + format(amazon_client.expiration.astimezone(get_localzone())))
+        print("Assuming " + config.role_arn, file=util.Util.get_output())
+        print("Credentials Expiration: " + format(amazon_client.expiration.astimezone(get_localzone())), file=util.Util.get_output())
 
     if config.print_creds:
         amazon_client.print_export_line()

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -32,9 +32,12 @@ def parse_args(args):
     parser.add_argument('-D', '--disable-u2f', action='store_true', help='Disable U2F functionality.')
     parser.add_argument('-q', '--quiet', action='store_true', help='Quiet output')
     parser.add_argument('--no-cache', dest="saml_cache", action='store_false', help='Do not cache the SAML Assertion.')
-    parser.add_argument('--print-creds', action='store_true', help='Print Credentials.')
     parser.add_argument('--resolve-aliases', action='store_true', help='Resolve AWS account aliases.')
     parser.add_argument('--save-failure-html', action='store_true', help='Write HTML failure responses to file for troubleshooting.')
+
+    print_group = parser.add_mutually_exclusive_group()
+    print_group.add_argument('--print-creds', action='store_true', help='Print Credentials.')
+    print_group.add_argument('--process-creds', action='store_true', help='Print Credentials in JSON format for AWS CLI credential_process directive.')
 
     role_group = parser.add_mutually_exclusive_group()
     role_group.add_argument('-a', '--ask-role', action='store_true', help='Set true to always pick the role')
@@ -160,6 +163,11 @@ def resolve_config(args):
         args.print_creds,
         config.print_creds)
 
+    config.process_creds = coalesce(
+        args.process_creds,
+        config.process_creds
+    )
+
     # Quiet
     config.quiet = coalesce(
         args.quiet,
@@ -244,6 +252,9 @@ def process_auth(args, config):
 
     if config.print_creds:
         amazon_client.print_export_line()
+
+    if config.process_creds:
+        amazon_client.print_credential_process()
 
     if config.profile:
         config.write(amazon_client)

--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -2,6 +2,7 @@
 
 import base64
 import os
+import json
 import boto3
 
 from datetime import datetime
@@ -71,6 +72,17 @@ class Amazon:
             self.secret_access_key,
             self.session_token,
             self.expiration.strftime('%Y-%m-%dT%H:%M:%S%z'))
+
+        print(formatted)
+
+    def print_credential_process(self):
+        formatted = json.dumps({
+            "Version": 1,
+            "AccessKeyId": self.access_key_id,
+            "SecretAccessKey": self.secret_access_key,
+            "SessionToken": self.session_token,
+            "Expiration": self.expiration.strftime('%Y-%m-%dT%H:%M:%S%z')
+        })
 
         print(formatted)
 

--- a/aws_google_auth/configuration.py
+++ b/aws_google_auth/configuration.py
@@ -34,6 +34,7 @@ class Configuration(object):
         self.resolve_aliases = False
         self.username = None
         self.print_creds = False
+        self.process_creds = False
         self.quiet = False
 
     # For the "~/.aws/config" file, we use the format "[profile testing]"

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -16,7 +16,7 @@ from distutils.spawn import find_executable
 from bs4 import BeautifulSoup
 from requests import HTTPError
 from six import print_ as print
-from six.moves import urllib_parse, input
+from six.moves import urllib_parse
 
 from aws_google_auth import _version
 from aws_google_auth import util

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -19,6 +19,7 @@ from six import print_ as print
 from six.moves import urllib_parse, input
 
 from aws_google_auth import _version
+from aws_google_auth import util
 
 # The U2F USB Library is optional, if it's there, include it.
 try:
@@ -367,7 +368,7 @@ class Google:
             if find_executable('xv') is None and find_executable('display') is None:
                 open_image = False
 
-        print("Please visit the following URL to view your CAPTCHA: {}".format(captcha_url))
+        print("Please visit the following URL to view your CAPTCHA: {}".format(captcha_url), file=util.Util.get_output())
 
         if open_image:
             try:
@@ -377,10 +378,7 @@ class Google:
             except Exception:
                 pass
 
-        try:
-            captcha_input = raw_input("Captcha (case insensitive): ") or None
-        except NameError:
-            captcha_input = input("Captcha (case insensitive): ") or None
+        captcha_input = util.Util.get_input("Captcha (case insensitive): ")
 
         # Update the payload
         payload['logincaptcha'] = captcha_input
@@ -430,9 +428,7 @@ class Google:
                 if attempts_remaining <= 0:
                     break
                 else:
-                    input(
-                        "Insert your U2F device and press enter to try again..."
-                    )
+                    util.Util.get_input("Insert your U2F device and press enter to try again...")
                     attempts_remaining -= 1
 
         # If we exceed the number of attempts, raise an error and let the program exit.
@@ -486,7 +482,7 @@ class Google:
         response_page = BeautifulSoup(sess.text, 'html.parser')
         challenge_url = sess.url.split("?")[0]
 
-        sms_token = input("Enter SMS token: G-") or None
+        sms_token = util.Util.get_input("Enter SMS token: G-")
 
         payload = {
             'challengeId':
@@ -552,7 +548,7 @@ class Google:
 
         self.check_prompt_code(response_page)
 
-        print("Open the Google App, and tap 'Yes' on the prompt to sign in ...")
+        print("Open the Google App, and tap 'Yes' on the prompt to sign in ...", file=util.Util.get_output())
 
         self.session.headers['Referer'] = sess.url
 
@@ -628,7 +624,7 @@ class Google:
         """
         num_code = response.find("div", {"jsname": "EKvSSd"})
         if num_code:
-            print("numerical code for prompt: {}".format(num_code.string))
+            print("numerical code for prompt: {}".format(num_code.string), file=util.Util.get_output())
 
     def handle_totp(self, sess):
         response_page = BeautifulSoup(sess.text, 'html.parser')
@@ -637,7 +633,7 @@ class Google:
         challenge_url = sess.url.split("?")[0]
         challenge_id = challenge_url.split("totp/")[1]
 
-        mfa_token = input("MFA token: ") or None
+        mfa_token = util.Util.get_input("MFA token: ")
 
         if not mfa_token:
             raise ValueError(
@@ -664,12 +660,12 @@ class Google:
     def handle_iap(self, sess):
         response_page = BeautifulSoup(sess.text, 'html.parser')
         challenge_url = sess.url.split("?")[0]
-        phone_number = input('Enter your phone number:') or None
+        phone_number = util.Util.get_input('Enter your phone number:')
 
         while True:
             try:
                 choice = int(
-                    input(
+                    util.Util.get_input(
                         'Type 1 to receive a code by SMS or 2 for a voice call:'
                     ))
                 if choice not in [1, 2]:
@@ -733,7 +729,7 @@ class Google:
         response_page = BeautifulSoup(sess.text, 'html.parser')
         challenge_url = sess.url.split("?")[0]
 
-        token = input("Enter " + send_method + " token: G-") or None
+        token = util.Util.get_input("Enter " + send_method + " token: G-")
 
         payload = {
             'challengeId':
@@ -813,12 +809,11 @@ class Google:
             if k in auth_methods and k not in unavailable_challenge_ids
         }
 
-        print('Choose MFA method from available:')
+        print('Choose MFA method from available:', file=util.Util.get_output())
         print('\n'.join(
-            '{}: {}'.format(*i) for i in list(auth_methods.items())))
+            '{}: {}'.format(*i) for i in list(auth_methods.items())), file=util.Util.get_output())
 
-        selected_challenge = input("Enter MFA choice number ({}): ".format(
-            challenge_ids[-1:][0])) or None
+        selected_challenge = util.Util.get_input("Enter MFA choice number ({}): ".format(challenge_ids[-1:][0]))
 
         if selected_challenge is not None and int(selected_challenge) in challenge_ids:
             challenge_id = int(selected_challenge)
@@ -826,7 +821,7 @@ class Google:
             # use the highest index as that will default to prompt, then sms, then totp, etc.
             challenge_id = challenge_ids[-1:][0]
 
-        print("MFA Type Chosen: {}".format(auth_methods[challenge_id]))
+        print("MFA Type Chosen: {}".format(auth_methods[challenge_id]), file=util.Util.get_output())
 
         # We need the specific form of the challenge chosen
         challenge_form = response_page.find(

--- a/aws_google_auth/tests/test_args_parser.py
+++ b/aws_google_auth/tests/test_args_parser.py
@@ -18,6 +18,7 @@ class TestPythonFailOnVersion(unittest.TestCase):
         self.assertTrue(parser.saml_cache)
         self.assertFalse(parser.ask_role)
         self.assertFalse(parser.print_creds)
+        self.assertFalse(parser.process_creds)
         self.assertFalse(parser.keyring)
         self.assertFalse(parser.resolve_aliases)
         self.assertFalse(parser.disable_u2f, None)
@@ -35,7 +36,7 @@ class TestPythonFailOnVersion(unittest.TestCase):
 
         # Assert the size of the parameter so that new parameters trigger a review of this function
         # and the appropriate defaults are added here to track backwards compatibility in the future.
-        self.assertEqual(len(vars(parser)), 16)
+        self.assertEqual(len(vars(parser)), 17)
 
     def test_username(self):
 

--- a/aws_google_auth/tests/test_init.py
+++ b/aws_google_auth/tests/test_init.py
@@ -58,6 +58,7 @@ class TestInit(unittest.TestCase):
                                          sp_id=None,
                                          log_level='warn',
                                          print_creds=False,
+                                         process_creds=False,
                                          username=None,
                                          quiet=False))
                           ],
@@ -77,6 +78,7 @@ class TestInit(unittest.TestCase):
                                          sp_id=None,
                                          log_level='warn',
                                          print_creds=False,
+                                         process_creds=False,
                                          username=None,
                                          quiet=False),
                                mock_config)
@@ -131,7 +133,8 @@ class TestInit(unittest.TestCase):
         self.assertEqual(mock_config.role_arn, "da_role")
 
         # Assert calls occur
-        self.assertEqual([call.Util.get_input('Google username: '),
+        self.assertEqual([call.Util.get_output(),
+                          call.Util.get_input('Google username: '),
                           call.Util.get_input('Google IDP ID: '),
                           call.Util.get_input('Google SP ID: '),
                           call.Util.get_password('Google Password: '),
@@ -203,7 +206,8 @@ class TestInit(unittest.TestCase):
         self.assertEqual(mock_config.role_arn, "da_role")
 
         # Assert calls occur
-        self.assertEqual([call.Util.get_input('Google username: '),
+        self.assertEqual([call.Util.get_output(),
+                          call.Util.get_input('Google username: '),
                           call.Util.get_input('Google IDP ID: '),
                           call.Util.get_input('Google SP ID: '),
                           call.Util.get_password('Google Password: '),
@@ -282,7 +286,8 @@ class TestInit(unittest.TestCase):
         self.assertEqual(mock_config.role_arn, "arn:aws:iam::123456789012:role/admin")
 
         # Assert calls occur
-        self.assertEqual([call.Util.get_input('Google username: '),
+        self.assertEqual([call.Util.get_output(),
+                          call.Util.get_input('Google username: '),
                           call.Util.get_input('Google IDP ID: '),
                           call.Util.get_input('Google SP ID: '),
                           call.Util.get_password('Google Password: ')],
@@ -349,7 +354,8 @@ class TestInit(unittest.TestCase):
         self.assertEqual(mock_config.role_arn, "da_role")
 
         # Assert calls occur
-        self.assertEqual([call.Util.get_input('Google username: '),
+        self.assertEqual([call.Util.get_output(),
+                          call.Util.get_input('Google username: '),
                           call.Util.get_input('Google IDP ID: '),
                           call.Util.get_input('Google SP ID: '),
                           call.Util.get_password('Google Password: '),
@@ -420,7 +426,8 @@ class TestInit(unittest.TestCase):
         self.assertEqual(mock_config.role_arn, "da_role")
 
         # Assert calls occur
-        self.assertEqual([call.Util.get_input('Google username: '),
+        self.assertEqual([call.Util.get_output(),
+                          call.Util.get_input('Google username: '),
                           call.Util.get_input('Google IDP ID: '),
                           call.Util.get_input('Google SP ID: '),
                           call.Util.get_password('Google Password: '),
@@ -492,7 +499,8 @@ class TestInit(unittest.TestCase):
         self.assertEqual(mock_config.role_arn, "da_role")
 
         # Assert calls occur
-        self.assertEqual([call.Util.pick_a_role({'arn:aws:iam::123456789012:role/read-only': 'arn:aws:iam::123456789012:saml-provider/GoogleApps',
+        self.assertEqual([call.Util.get_output(),
+                          call.Util.pick_a_role({'arn:aws:iam::123456789012:role/read-only': 'arn:aws:iam::123456789012:saml-provider/GoogleApps',
                                                 'arn:aws:iam::123456789012:role/admin': 'arn:aws:iam::123456789012:saml-provider/GoogleApps'}, [])],
                          mock_util.mock_calls)
 

--- a/aws_google_auth/u2f.py
+++ b/aws_google_auth/u2f.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import json
 import time
 
 import requests
+from six import print_ as print
+
 from u2flib_host import u2f, exc, appid
 from u2flib_host.constants import APDU_USE_NOT_SATISFIED
 
@@ -67,8 +70,8 @@ def u2f_auth(challenges, facet):
                         if e.code == APDU_USE_NOT_SATISFIED:
                             remove = False
                             if not prompted:
-                                print('Touch the flashing U2F device to '
-                                      'authenticate...', file=util.Util.get_output())
+                                print('Touch the flashing U2F device to authenticate...',
+                                      file=util.Util.get_output())
                                 prompted = True
                         else:
                             pass

--- a/aws_google_auth/u2f.py
+++ b/aws_google_auth/u2f.py
@@ -7,6 +7,9 @@ import requests
 from u2flib_host import u2f, exc, appid
 from u2flib_host.constants import APDU_USE_NOT_SATISFIED
 
+from aws_google_auth import util
+
+
 """
 The facet/appID used by Google auth does not seem to be valid
 Need to apply some patches to u2flib_host to not validate the
@@ -65,7 +68,7 @@ def u2f_auth(challenges, facet):
                             remove = False
                             if not prompted:
                                 print('Touch the flashing U2F device to '
-                                      'authenticate...')
+                                      'authenticate...', file=util.Util.get_output())
                                 prompted = True
                         else:
                             pass

--- a/aws_google_auth/util.py
+++ b/aws_google_auth/util.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import getpass
 import os
 import sys
+import io
 from collections import OrderedDict
 
 from six.moves import input
@@ -15,7 +16,8 @@ class Util:
 
     @staticmethod
     def get_input(prompt):
-        return input(prompt)
+        print(prompt, file=Util.get_output(), end='', flush=True)
+        return input() or None
 
     @staticmethod
     def pick_a_role(roles, aliases=None):
@@ -38,18 +40,18 @@ class Util:
                 enriched_roles_tab.append([i + 1, role_property[0], role_property[1]])
 
             while True:
-                print(tabulate(enriched_roles_tab, headers=['No', 'AWS account', 'Role'], ))
+                print(tabulate(enriched_roles_tab, headers=['No', 'AWS account', 'Role'], ), file=Util.get_output())
                 prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(enriched_roles))
                 choice = Util.get_input(prompt)
 
                 try:
                     return list(ordered_roles.items())[int(choice) - 1]
                 except (IndexError, ValueError):
-                    print("Invalid choice, try again.")
+                    print("Invalid choice, try again.", file=Util.get_output())
         else:
             while True:
                 for i, role in enumerate(roles):
-                    print("[{:>3d}] {}".format(i + 1, role))
+                    print("[{:>3d}] {}".format(i + 1, role), file=Util.get_output())
 
                 prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(roles))
                 choice = Util.get_input(prompt)
@@ -57,7 +59,7 @@ class Util:
                 try:
                     return list(roles.items())[int(choice) - 1]
                 except (IndexError, ValueError):
-                    print("Invalid choice, try again.")
+                    print("Invalid choice, try again.", file=Util.get_output())
 
     @staticmethod
     def touch(file_name, mode=0o600):
@@ -95,3 +97,16 @@ class Util:
             password = sys.stdin.readline()
             print("")
         return password
+
+
+    out_tty = None
+
+    @staticmethod
+    def get_output():
+        if Util.out_tty is None:
+            Util.out_tty = io.TextIOWrapper(
+                io.FileIO(
+                    os.open("/dev/tty", os.O_RDWR|os.O_NOCTTY),
+                    "r+"),
+                line_buffering=True)
+        return Util.out_tty

--- a/aws_google_auth/util.py
+++ b/aws_google_auth/util.py
@@ -98,15 +98,13 @@ class Util:
             print("")
         return password
 
-
     out_tty = None
-
     @staticmethod
     def get_output():
         if Util.out_tty is None:
             Util.out_tty = io.TextIOWrapper(
                 io.FileIO(
-                    os.open("/dev/tty", os.O_RDWR|os.O_NOCTTY),
+                    os.open("/dev/tty", os.O_RDWR | os.O_NOCTTY),
                     "r+"),
                 line_buffering=True)
         return Util.out_tty


### PR DESCRIPTION
Add `--process-creds` option to partially address #40

Allows the `~/.aws/config` file to use the `credential_process` directive
with _aws-google-auth_, so that users can use AWS CLI profiles without
calling the _aws-google-auth_ tool directly.

Please note that the AWS CLI does not currently cache credentials
obtained from an external `credential_process`.
The _aws-google-auth_ `--profile` option 'caches' the authentication tokens
in the `~/.aws/credentials` file, which effectively caches the results.

Additionally, the `~/.aws/config` profile cannot be used as a
`source_profile` for another profile, so is unable to assume roles in
other accounts. See boto/botocore#1329

---

Please bear with me as this is my first PR, and my Python experience is limited.

Cheers,
Neil