### PR TITLE
Add more information about the default duration CLI argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,8 @@ Usage
       -R REGION, --region REGION
                             AWS region endpoint ($AWS_DEFAULT_REGION)
       -d DURATION, --duration DURATION
-                            Credential duration ($DURATION)
+                            Credential duration (defaults to value of $DURATION, then
+                            falls back to 43200)
       -p PROFILE, --profile PROFILE
                             AWS profile (defaults to value of $AWS_PROFILE, then
                             falls back to 'sts')
@@ -150,7 +151,7 @@ Usage
       -V, --version         show program's version number and exit
 
 
-**Note** that if you want longer than the default 3600 seconds (1 hour)
+**Note** If you want a longer session than the AWS default 3600 seconds (1 hour)
 duration, you must also modify the IAM Role to permit this. See
 `the AWS documentation <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html>`__
 for more information.

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -27,7 +27,7 @@ def parse_args(args):
     parser.add_argument('-I', '--idp-id', help='Google SSO IDP identifier ($GOOGLE_IDP_ID)')
     parser.add_argument('-S', '--sp-id', help='Google SSO SP identifier ($GOOGLE_SP_ID)')
     parser.add_argument('-R', '--region', help='AWS region endpoint ($AWS_DEFAULT_REGION)')
-    parser.add_argument('-d', '--duration', type=int, help='Credential duration ($DURATION)')
+    parser.add_argument('-d', '--duration', type=int, help='Credential duration in seconds (defaults to value of $DURATION, then falls back to 43200)')
     parser.add_argument('-p', '--profile', help='AWS profile (defaults to value of $AWS_PROFILE, then falls back to \'sts\')')
     parser.add_argument('-D', '--disable-u2f', action='store_true', help='Disable U2F functionality.')
     parser.add_argument('-q', '--quiet', action='store_true', help='Quiet output')


### PR DESCRIPTION
I think the current command line args for duration aren't too clear, as the default duration we set to 12h which is higher than the default. So this hints towards that on the CLI argument, and also makes it more clear on the README