### PR TITLE
Retry opening U2F devices, improves reliability

### DIFF
--- a/aws_google_auth/u2f.py
+++ b/aws_google_auth/u2f.py
@@ -48,7 +48,12 @@ def u2f_auth(challenges, facet):
         try:
             device.open()
         except:
-            devices.remove(device)
+            # Some U2F devices fail on the first attempt to open but
+            # succeed on subsequent attempts. So retry once.
+            try:
+                device.open()
+            except:
+                devices.remove(device)
 
     try:
         prompted = False


### PR DESCRIPTION
Some U2F devices fail to open on the first attempt but open reliably
after that. So retry once to minimise the unplug/replug dance.