### PR TITLE
Add support for --bg-response challenge override

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,8 @@ Usage
                             falls back to 'sts')
       -D, --disable-u2f     Disable U2F functionality.
       -q, --quiet           Quiet output
+      --bg-response BG_RESPONSE
+                            Override default bgresponse challenge token ($GOOGLE_BG_RESPONSE).
       --no-cache            Do not cache the SAML Assertion.
       --print-creds         Print Credentials.
       --resolve-aliases     Resolve AWS account aliases.

--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -31,6 +31,7 @@ def parse_args(args):
     parser.add_argument('-p', '--profile', help='AWS profile (defaults to value of $AWS_PROFILE, then falls back to \'sts\')')
     parser.add_argument('-D', '--disable-u2f', action='store_true', help='Disable U2F functionality.')
     parser.add_argument('-q', '--quiet', action='store_true', help='Quiet output')
+    parser.add_argument('--bg-response', help='Override default bgresponse challenge token.')
     parser.add_argument('--no-cache', dest="saml_cache", action='store_false', help='Do not cache the SAML Assertion.')
     parser.add_argument('--print-creds', action='store_true', help='Print Credentials.')
     parser.add_argument('--resolve-aliases', action='store_true', help='Resolve AWS account aliases.')
@@ -164,6 +165,11 @@ def resolve_config(args):
     config.quiet = coalesce(
         args.quiet,
         config.quiet)
+
+    config.bg_response = coalesce(
+        args.bg_response,
+        os.getenv('GOOGLE_BG_RESPONSE'),
+        config.bg_response)
 
     return config
 

--- a/aws_google_auth/configuration.py
+++ b/aws_google_auth/configuration.py
@@ -35,6 +35,7 @@ class Configuration(object):
         self.username = None
         self.print_creds = False
         self.quiet = False
+        self.bg_response = None
 
     # For the "~/.aws/config" file, we use the format "[profile testing]"
     # for the 'testing' profile. The credential file will just be "[testing]"
@@ -159,6 +160,7 @@ class Configuration(object):
         config_parser.set(profile, 'google_config.google_sp_id', self.sp_id)
         config_parser.set(profile, 'google_config.u2f_disabled', self.u2f_disabled)
         config_parser.set(profile, 'google_config.google_username', self.username)
+        config_parser.set(profile, 'google_config.bg_response', self.bg_response)
         with open(self.config_file, 'w+') as f:
             config_parser.write(f)
 
@@ -234,6 +236,10 @@ class Configuration(object):
             # Username
             read_username = unicode_to_string(config_parser[profile_string].get('google_config.google_username', None))
             self.username = coalesce(read_username, self.username)
+
+            # bg_response
+            read_bg_response = unicode_to_string(config_parser[profile_string].get('google_config.bg_response', None))
+            self.bg_response = coalesce(read_bg_response, self.bg_response)
 
         # SAML Cache
         try:

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -206,6 +206,9 @@ class Google:
             '_utf8': '?',
         }
 
+        if self.config.bg_response:
+            payload['bgresponse'] = self.config.bg_response
+
         # GALX is sometimes not there
         try:
             galx = first_page.find('input', {'name': 'GALX'}).get('value')
@@ -250,6 +253,11 @@ class Google:
         # or someone using the same outbound IP address as you, is a bot.
         if error is not None:
             raise ExpectedGoogleException('Invalid username or password')
+
+        if "signin/rejected" in sess.url:
+            raise ExpectedGoogleException(u'''Default value of parameter `bgresponse` has not accepted.
+                Please visit login URL {}, open the web inspector and execute document.bg.invoke() in the console.
+                Then, set --bg-response to the function output.'''.format(self.login_url))
 
         self.check_extra_step(response_page)
 

--- a/aws_google_auth/tests/test_args_parser.py
+++ b/aws_google_auth/tests/test_args_parser.py
@@ -30,12 +30,13 @@ class TestPythonFailOnVersion(unittest.TestCase):
         self.assertEqual(parser.role_arn, None)
         self.assertEqual(parser.username, None)
         self.assertEqual(parser.quiet, False)
+        self.assertEqual(parser.bg_response, None)
 
         self.assertFalse(parser.save_failure_html)
 
         # Assert the size of the parameter so that new parameters trigger a review of this function
         # and the appropriate defaults are added here to track backwards compatibility in the future.
-        self.assertEqual(len(vars(parser)), 16)
+        self.assertEqual(len(vars(parser)), 17)
 
     def test_username(self):
 

--- a/aws_google_auth/tests/test_config_parser.py
+++ b/aws_google_auth/tests/test_config_parser.py
@@ -229,3 +229,23 @@ class TestResolveAliasesProcessing(unittest.TestCase):
         args = parse_args([])
         config = resolve_config(args)
         self.assertTrue(config.resolve_aliases)
+
+
+class TestBgResponseProcessing(unittest.TestCase):
+
+    def test_default(self):
+        args = parse_args([])
+        config = resolve_config(args)
+        self.assertFalse(config.resolve_aliases)
+
+    def test_cli_param_supplied(self):
+        args = parse_args(['--bg-response=foo'])
+        config = resolve_config(args)
+        self.assertEqual(config.bg_response, 'foo')
+
+    @nottest
+    @mock.patch.dict(os.environ, {'GOOGLE_BG_RESPONSE': 'foo'})
+    def test_with_environment(self):
+        args = parse_args([])
+        config = resolve_config(args)
+        self.assertEqual(config.bg_response, 'foo')

--- a/aws_google_auth/tests/test_configuration_persistence.py
+++ b/aws_google_auth/tests/test_configuration_persistence.py
@@ -30,6 +30,7 @@ class TestConfigurationPersistence(unittest.TestCase):
         self.c.sp_id = "sample_sp_id"
         self.c.u2f_disabled = False
         self.c.username = "sample_username"
+        self.c.bg_response = "foo"
         self.c.raise_if_invalid()
         self.c.write(None)
 
@@ -54,6 +55,7 @@ class TestConfigurationPersistence(unittest.TestCase):
         self.assertEqual(self.config_parser[profile_string].getboolean('google_config.keyring'), self.c.keyring)
         self.assertEqual(self.config_parser[profile_string].getboolean('google_config.u2f_disabled'), self.c.u2f_disabled)
         self.assertEqual(self.config_parser[profile_string].getint('google_config.duration'), self.c.duration)
+        self.assertEqual(self.config_parser[profile_string].get('google_config.bg_response'), self.c.bg_response)
 
     def test_password_not_written(self):
         profile_string = configuration.Configuration.config_profile(self.c.profile)
@@ -85,3 +87,4 @@ class TestConfigurationPersistence(unittest.TestCase):
         self.assertEqual(test_configuration.u2f_disabled, self.c.u2f_disabled)
         self.assertEqual(test_configuration.duration, self.c.duration)
         self.assertEqual(test_configuration.keyring, self.c.keyring)
+        self.assertEqual(test_configuration.bg_response, self.c.bg_response)

--- a/aws_google_auth/tests/test_init.py
+++ b/aws_google_auth/tests/test_init.py
@@ -59,7 +59,8 @@ class TestInit(unittest.TestCase):
                                          log_level='warn',
                                          print_creds=False,
                                          username=None,
-                                         quiet=False))
+                                         quiet=False,
+                                         bg_response=None))
                           ],
                          resolve_config.mock_calls)
 
@@ -78,7 +79,8 @@ class TestInit(unittest.TestCase):
                                          log_level='warn',
                                          print_creds=False,
                                          username=None,
-                                         quiet=False),
+                                         quiet=False,
+                                         bg_response=None),
                                mock_config)
                           ],
                          process_auth.mock_calls)


### PR DESCRIPTION
Hi,

Recently, I have started experiencing an issue obtaining credentials with the usual fatal error of "Could not find SAML response, check your credentials". Debugging led me to believe it is connected with the fact that `bgresponse` is set to `js_disabled`, which is the input's default value before a javascript function call modifies it during submission.

This is the same behavior you will get if you attempt to authenticate with javascript disabled:

![Screen Shot 2019-09-11 at 01 38 44](https://user-images.githubusercontent.com/288709/64659791-67b85680-d435-11e9-8385-e09e4560e97c.png)

Some research suggests `bg` stands for Botguard, a reCaptcha (-like) service to score the reputation of the request.

I don't know if Google is getting more aggressive fighting bots and this is only a step forward in that direction, or if for some other reason my account started requiring elevated checks.

In any case, the only workaround I have found is to generate a `bgresponse` token once by invoking `document.bg.invoke()` in the web console on the login URL. This token can be persisted and at the moment I do not know for how long will it remain valid. This PR will detect a rejected signin attempt and prompt the user to restart the process with the `--bg-response` parameter set. In the future, this could be done interactively.

As far as I am aware, it is not possible to execute this javascript call inside python (using bs4 or other parser) since we're just parsing text. A headless browser would be required instead, leading to a complete refactor. 

There might be other ways of fixing this, but what I have noticed is that as soon as you hit this dead wall, you'll be stuck without this PR.

**Testing**

1. Clone this branch.
1. Change directory to the cloned folder and run `export PYTHONPATH="$(pwd)"`.
1. Run `python3 aws_google_auth/__init__.py`.

![carbon](https://user-images.githubusercontent.com/288709/68248929-b5a4a180-0015-11ea-9298-96892d2894ef.png)
