### PR TITLE
Add missing $AWS_ROLE_ARN variable support to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ Usage
                             troubleshooting.
       -a, --ask-role        Set true to always pick the role
       -r ROLE_ARN, --role-arn ROLE_ARN
-                            The ARN of the role to assume
+                            The ARN of the role to assume ($AWS_ROLE_ARN)
       -k, --keyring         Use keyring for storing the password.
       -V, --version         show program's version number and exit
 


### PR DESCRIPTION
While introducing a different PR, I have noticed the ARN role can also be set using an environment variable. Could prove useful to some setups.