### PR TITLE
allow govcloud style arns

### DIFF
--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -79,7 +79,7 @@ class Amazon:
         doc = etree.fromstring(self.saml_xml)
         roles = {}
         for x in doc.xpath('//*[@Name = "https://aws.amazon.com/SAML/Attributes/Role"]//text()'):
-            if "arn:aws:iam:" in x:
+            if "arn:aws:iam:" in x or "arn:aws-us-gov:iam:" in x:
                 res = x.split(',')
                 roles[res[0]] = res[1]
         return roles

--- a/aws_google_auth/configuration.py
+++ b/aws_google_auth/configuration.py
@@ -129,7 +129,7 @@ class Configuration(object):
         # role_arn (Can be blank, we'll just prompt)
         if self.role_arn is not None:
             assert (self.role_arn.__class__ is str), "Expected role_arn to be None or a string. Got {}.".format(self.role_arn.__class__)
-            assert ("arn:aws:iam::" in self.role_arn), "Expected role_arn to contain 'arn:aws:iam::'. Got '{}'.".format(self.role_arn)
+            assert ("arn:aws:iam::" in self.role_arn or "arn:aws-us-gov:iam::" in self.role_arn), "Expected role_arn to contain 'arn:aws:iam::'. Got '{}'.".format(self.role_arn)
 
         # u2f_disabled
         assert (self.u2f_disabled.__class__ is bool), "Expected u2f_disabled to be a boolean. Got {}.".format(self.u2f_disabled.__class__)


### PR DESCRIPTION
I was testing this out with GovCloud and added a small patch to update the ARN format checking to allow for `arn:aws-us-gov` prefix instead of just `arn:aws:`. 