### PR TITLE
Add support for parallel authentications

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4
 boto3
 configparser
+filelock
 keyring
 lxml
 Pillow

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,11 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     # install_requires=['peppercorn'],
-    install_requires=['beautifulsoup4', 'boto3', 'configparser', 'keyring',
-        'keyrings.alt', 'lxml', 'Pillow', 'requests', 'six', 'tabulate',
-        'tzlocal'],
+    install_requires=[
+        'beautifulsoup4', 'boto3', 'configparser', 'filelock',
+        'keyring', 'keyrings.alt', 'lxml', 'Pillow', 'requests',
+        'six', 'tabulate', 'tzlocal'
+    ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Login to multiple locations by running the cli in parallel.
Fixes an issue where concurrent read and writes of the config end up breaking it or overwriting credentials.

Changes:
* Use a filelock lib for cross-process locking of read/write config operations