### PR TITLE
Accept shell command parameters to automate things

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,10 @@ Usage
       --resolve-aliases     Resolve AWS account aliases.
       --save-failure-html   Write HTML failure responses to file for
                             troubleshooting.
+      --password-cmd PASSWORD_CMD
+                            System shell command to get password from its output.
+      --token-cmd TOKEN_CMD
+                            System shell command to get 2FA token from its output.
       -a, --ask-role        Set true to always pick the role
       -r ROLE_ARN, --role-arn ROLE_ARN
                             The ARN of the role to assume ($AWS_ROLE_ARN)

--- a/aws_google_auth/configuration.py
+++ b/aws_google_auth/configuration.py
@@ -39,6 +39,8 @@ class Configuration(object):
         self.quiet = False
         self.bg_response = None
         self.account = ""
+        self.password_cmd = None
+        self.token_cmd = None
 
     # For the "~/.aws/config" file, we use the format "[profile testing]"
     # for the 'testing' profile. The credential file will just be "[testing]"

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -682,7 +682,11 @@ class Google:
         challenge_url = sess.url.split("?")[0]
         challenge_id = challenge_url.split("totp/")[1]
 
-        mfa_token = input("MFA token: ") or None
+        if self.config.token_cmd:
+            with os.popen(self.config.token_cmd) as subproc:
+                mfa_token = subproc.read().strip()
+        else:
+            mfa_token = input("MFA token: ") or None
 
         if not mfa_token:
             raise ValueError(

--- a/aws_google_auth/tests/test_args_parser.py
+++ b/aws_google_auth/tests/test_args_parser.py
@@ -39,7 +39,7 @@ class TestPythonFailOnVersion(unittest.TestCase):
 
         # Assert the size of the parameter so that new parameters trigger a review of this function
         # and the appropriate defaults are added here to track backwards compatibility in the future.
-        self.assertEqual(len(vars(parser)), 20)
+        self.assertEqual(len(vars(parser)), 22)
 
     def test_username(self):
 

--- a/aws_google_auth/tests/test_init.py
+++ b/aws_google_auth/tests/test_init.py
@@ -63,7 +63,9 @@ class TestInit(unittest.TestCase):
                                          username=None,
                                          quiet=False,
                                          bg_response=None,
-                                         account=None))
+                                         account=None,
+                                         password_cmd=None,
+                                         token_cmd=None))
                           ],
                          resolve_config.mock_calls)
 
@@ -86,7 +88,9 @@ class TestInit(unittest.TestCase):
                                          username=None,
                                          quiet=False,
                                          bg_response=None,
-                                         account=None),
+                                         account=None,
+                                         password_cmd=None,
+                                         token_cmd=None),
                                mock_config)
                           ],
                          process_auth.mock_calls)
@@ -106,6 +110,7 @@ class TestInit(unittest.TestCase):
         mock_config.return_value = None
         mock_config.account = None
         mock_config.region = None
+        mock_config.password_cmd = None
 
         mock_amazon_client = Mock()
         mock_google_client = Mock()
@@ -180,6 +185,7 @@ class TestInit(unittest.TestCase):
         mock_config.return_value = None
         mock_config.print_creds = True
         mock_config.account = None
+        mock_config.password_cmd = None
 
         mock_amazon_client = Mock()
         mock_google_client = Mock()
@@ -257,6 +263,7 @@ class TestInit(unittest.TestCase):
         mock_config.idp_id = None
         mock_config.sp_id = None
         mock_config.return_value = None
+        mock_config.password_cmd = None
 
         mock_config.role_arn = 'arn:aws:iam::123456789012:role/admin'
         mock_config.ask_role = False
@@ -328,6 +335,7 @@ class TestInit(unittest.TestCase):
         mock_config.return_value = None
         mock_config.keyring = False
         mock_config.account = None
+        mock_config.password_cmd = None
 
         mock_amazon_client = Mock()
         mock_google_client = Mock()
@@ -401,6 +409,7 @@ class TestInit(unittest.TestCase):
         mock_config.return_value = None
         mock_config.role_arn = 'arn:aws:iam::123456789012:role/admin'
         mock_config.account = None
+        mock_config.password_cmd = None
 
         mock_amazon_client = Mock()
         mock_google_client = Mock()
@@ -528,3 +537,31 @@ class TestInit(unittest.TestCase):
         self.assertEqual([call({'arn:aws:iam::123456789012:role/read-only': 'arn:aws:iam::123456789012:saml-provider/GoogleApps',
                                 'arn:aws:iam::123456789012:role/admin': 'arn:aws:iam::123456789012:saml-provider/GoogleApps'}, [])
                           ], mock_util_obj.pick_a_role.mock_calls)
+
+    @patch('aws_google_auth.util', spec=True)
+    @patch('aws_google_auth.amazon', spec=True)
+    @patch('aws_google_auth.google', spec=True)
+    def test_process_with_password_cmd(self, mock_google, mock_amazon, mock_util):
+
+        mock_config = Mock()
+        mock_config.saml_cache = False
+        mock_config.username = "input"
+        mock_config.idp_id = "input2"
+        mock_config.sp_id = "input3"
+        mock_config.region = "region_input"
+        mock_config.password_cmd = "echo '123'"
+        mock_config.provider = "da_provider"
+        mock_config.role_arn = "da_role"
+        mock_config.ask_role = False
+
+        mock_amazon_client = Mock()
+        mock_amazon_client.roles = {'da_role': 'da_role'}
+        mock_amazon.Amazon = MagicMock(return_value=mock_amazon_client)
+
+        args = aws_google_auth.parse_args([])
+
+        # Method Under Test
+        aws_google_auth.process_auth(args, mock_config)
+
+        # Assert values collected
+        self.assertEqual(mock_config.password, "123")


### PR DESCRIPTION
Hi, I definitely understand the purpose of 2FA, but I really need to automate some things in my workflow:
```
# using `gopass` (gpg-encrypted passwords in a git repo)
gopass show -f -o '...'
# and a separate host for 2fa secrets like that
ssh user@host 'oathtool --totp -b $(cat secret)'
```
