### PR TITLE
Print mostly to stderr so users can source the export line

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-
 import argparse
 import base64
 import os
@@ -8,7 +6,6 @@ import sys
 import logging
 
 import keyring
-from six import print_ as print
 from tzlocal import get_localzone
 
 from aws_google_auth import _version
@@ -77,7 +74,7 @@ def cli(cli_args):
         config = resolve_config(args)
         process_auth(args, config)
     except google.ExpectedGoogleException as ex:
-        print(ex)
+        logging.error(ex)
         sys.exit(1)
     except KeyboardInterrupt:
         pass
@@ -274,8 +271,8 @@ def process_auth(args, config):
         else:
             config.role_arn, config.provider = util.Util.pick_a_role(roles)
     if not config.quiet:
-        print("Assuming " + config.role_arn)
-        print("Credentials Expiration: " + format(amazon_client.expiration.astimezone(get_localzone())))
+        util.Util.message("Assuming " + config.role_arn)
+        util.Util.message("Credentials Expiration: " + format(amazon_client.expiration.astimezone(get_localzone())))
 
     if config.print_creds:
         amazon_client.print_export_line()

--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import base64
 import boto3
@@ -72,6 +73,7 @@ class Amazon:
             self.session_token,
             self.expiration.strftime('%Y-%m-%dT%H:%M:%S%z'))
 
+        # Print to stdout (not stderr) so the output can be sourced by a shell.
         print(formatted)
 
     @property

--- a/aws_google_auth/u2f.py
+++ b/aws_google_auth/u2f.py
@@ -7,6 +7,8 @@ import requests
 from u2flib_host import u2f, exc, appid
 from u2flib_host.constants import APDU_USE_NOT_SATISFIED
 
+from aws_google_auth.util import Util
+
 """
 The facet/appID used by Google auth does not seem to be valid
 Need to apply some patches to u2flib_host to not validate the
@@ -69,8 +71,9 @@ def u2f_auth(challenges, facet):
                         if e.code == APDU_USE_NOT_SATISFIED:
                             remove = False
                             if not prompted:
-                                print('Touch the flashing U2F device to '
-                                      'authenticate...')
+                                Util.message(
+                                    'Touch the flashing U2F device to '
+                                    'authenticate...')
                                 prompted = True
                         else:
                             pass

--- a/aws_google_auth/util.py
+++ b/aws_google_auth/util.py
@@ -15,7 +15,8 @@ class Util:
 
     @staticmethod
     def get_input(prompt):
-        return input(prompt)
+        Util.message(prompt, end="")
+        return input()
 
     @staticmethod
     def pick_a_role(roles, aliases=None, account=None):
@@ -43,18 +44,18 @@ class Util:
                 enriched_roles_tab.append([i + 1, role_property[0], role_property[1]])
 
             while True:
-                print(tabulate(enriched_roles_tab, headers=['No', 'AWS account', 'Role'], ))
+                Util.message(tabulate(enriched_roles_tab, headers=['No', 'AWS account', 'Role'], ))
                 prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(enriched_roles))
                 choice = Util.get_input(prompt)
 
                 try:
                     return list(ordered_roles.items())[int(choice) - 1]
                 except (IndexError, ValueError):
-                    print("Invalid choice, try again.")
+                    Util.message("Invalid choice, try again.")
         else:
             while True:
                 for i, role in enumerate(filtered_roles):
-                    print("[{:>3d}] {}".format(i + 1, role))
+                    Util.message("[{:>3d}] {}".format(i + 1, role))
 
                 prompt = 'Type the number (1 - {:d}) of the role to assume: '.format(len(filtered_roles))
                 choice = Util.get_input(prompt)
@@ -62,7 +63,7 @@ class Util:
                 try:
                     return list(filtered_roles.items())[int(choice) - 1]
                 except (IndexError, ValueError):
-                    print("Invalid choice, try again.")
+                    Util.message("Invalid choice, try again.")
 
     @staticmethod
     def touch(file_name, mode=0o600):
@@ -95,8 +96,12 @@ class Util:
         if sys.stdin.isatty():
             password = getpass.getpass(prompt)
         else:
-            print(prompt, end="")
-            sys.stdout.flush()
+            Util.message(prompt, end="")
             password = sys.stdin.readline()
-            print("")
+            Util.message("")
         return password
+
+    @staticmethod
+    def message(*msg, **print_kwargs):
+        """Print a user-interaction message to stderr."""
+        print(*msg, file=sys.stderr, **print_kwargs)


### PR DESCRIPTION
This makes it possible to do things like:

    source <(aws-google-auth --print-creds)

... to avoid the copy-and-paste routine that would otherwise be
necessary to set the various shell variables.