### PR TITLE
Handle accounts that are invalid

### DIFF
--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -120,29 +120,24 @@ class Amazon:
 
     def resolve_aws_aliases(self, roles):
         def resolve_aws_alias(role, principal, aws_dict):
-            session = boto3.session.Session(region_name=self.config.region)
-
-            sts = session.client('sts')
-            saml = sts.assume_role_with_saml(RoleArn=role,
-                                             PrincipalArn=principal,
-                                             SAMLAssertion=self.base64_encoded_saml)
-
-            iam = session.client('iam',
-                                 aws_access_key_id=saml['Credentials']['AccessKeyId'],
-                                 aws_secret_access_key=saml['Credentials']['SecretAccessKey'],
-                                 aws_session_token=saml['Credentials']['SessionToken'])
             try:
-                response = iam.list_account_aliases()
-                account_alias = response['AccountAliases'][0]
-                aws_dict[role.split(':')[4]] = account_alias
-            except:
-                sts = session.client('sts',
+                session = boto3.session.Session(region_name=self.config.region)
+
+                sts = session.client('sts')
+                saml = sts.assume_role_with_saml(RoleArn=role,
+                                                 PrincipalArn=principal,
+                                                 SAMLAssertion=self.base64_encoded_saml)
+
+                iam = session.client('iam',
                                      aws_access_key_id=saml['Credentials']['AccessKeyId'],
                                      aws_secret_access_key=saml['Credentials']['SecretAccessKey'],
                                      aws_session_token=saml['Credentials']['SessionToken'])
 
-                account_id = sts.get_caller_identity().get('Account')
-                aws_dict[role.split(':')[4]] = '{}'.format(account_id)
+                response = iam.list_account_aliases()
+                account_alias = response['AccountAliases'][0]
+                aws_dict[role.split(':')[4]] = account_alias
+            except:
+                aws_dict[role.split(':')[4]] = role.split(':')[4]
 
         threads = []
         aws_id_alias = {}


### PR DESCRIPTION
when resolving aliases, some roles might be used that actually don't work right now, this change allows these to just show the account number