### PR TITLE
Add dual-prompt to list of challenge choices

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -840,6 +840,8 @@ class Google:
                 challenges.append(['YubiKey', i.attrs.get("data-challengeentry")])
             elif "challenge/az/" in action:
                 challenges.append(['Google Prompt', i.attrs.get("data-challengeentry")])
+            elif "challenge/dp/" in action:
+                challenges.append(['Google Dual Prompt', i.attrs.get('data-challengeentry')])
 
         print('Choose MFA method from available:')
         for i, mfa in enumerate(challenges, start=1):


### PR DESCRIPTION
This fixes a small issue from 77e7544 (#206) where the code for
handling the dual-prompt page was added, but the support for it
wasn't added in the challenge-selection stage. This adds the `elif`
clause neeeded to parse the dual prompt method.

(Tested against 0.0.37 and login works successfully after this
commit is applied.)

Fixes #200