### PR TITLE
Parse role specification more robustly

### DIFF
--- a/aws_google_auth/amazon.py
+++ b/aws_google_auth/amazon.py
@@ -80,7 +80,8 @@ class Amazon:
         roles = {}
         for x in doc.xpath('//*[@Name = "https://aws.amazon.com/SAML/Attributes/Role"]//text()'):
             if "arn:aws:iam:" in x or "arn:aws-us-gov:iam:" in x:
-                res = x.split(',')
+                res = sorted([s.strip() for s in x.split(',')],
+                              key=lambda s: ':role/' in s, reverse=True)
                 roles[res[0]] = res[1]
         return roles
 


### PR DESCRIPTION
Handle some variation on the role specification that seem to be supported both by AWS and Google.
 - Whitespace next to the coma that separates role and provider
 - Inverted order of provider,role (instead of role,provider)
 
 Fixes #163 