### PR TITLE
Add timeouts to http requests

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -11,6 +11,12 @@ import keyring
 from six import print_ as print
 from tzlocal import get_localzone
 
+# HTTP request timeouts (in seconds).
+# 3s is the default TCP retransmission window, that's why we use values slightly larger
+# than multiples of 3.
+CONNECT_TIMEOUT = 3.05
+READ_TIMEOUT = 9.05
+
 from aws_google_auth import _version
 from aws_google_auth import amazon
 from aws_google_auth import configuration

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -19,7 +19,7 @@ from requests import HTTPError
 from six import print_ as print
 from six.moves import urllib_parse, input
 
-from aws_google_auth import _version
+from aws_google_auth import _version, CONNECT_TIMEOUT, READ_TIMEOUT
 
 # The U2F USB Library is optional, if it's there, include it.
 try:
@@ -121,7 +121,14 @@ class Google:
     def post(self, url, data=None, json_data=None):
         try:
             self._save_request(url, method='POST', data=data, json_data=json_data)
-            response = self.check_for_failure(self.session.post(url, data=data, json=json_data))
+            response = self.check_for_failure(
+                self.session.post(
+                    url,
+                    data=data,
+                    json=json_data,
+                    timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+                )
+            )
             self._save_response(url, response)
 
         except requests.exceptions.ConnectionError as e:
@@ -141,7 +148,9 @@ class Google:
     def get(self, url):
         try:
             self._save_request(url)
-            response = self.check_for_failure(self.session.get(url))
+            response = self.check_for_failure(
+                self.session.get(url, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
+            )
             self._save_response(url, response)
 
         except requests.exceptions.ConnectionError as e:
@@ -404,7 +413,9 @@ class Google:
 
         if open_image:
             try:
-                with requests.get(captcha_url) as url:
+                with requests.get(
+                    captcha_url, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT)
+                ) as url:
                     with io.BytesIO(url.content) as f:
                         Image.open(f).show()
             except Exception:

--- a/aws_google_auth/u2f.py
+++ b/aws_google_auth/u2f.py
@@ -7,6 +7,8 @@ import requests
 from u2flib_host import u2f, exc, appid
 from u2flib_host.constants import APDU_USE_NOT_SATISFIED
 
+from aws_google_auth import CONNECT_TIMEOUT, READ_TIMEOUT
+
 """
 The facet/appID used by Google auth does not seem to be valid
 Need to apply some patches to u2flib_host to not validate the
@@ -20,7 +22,12 @@ valid for the facet https://accounts.google.com)
 def __appid_verifier__fetch_json(app_id):
     target = app_id
     while True:
-        resp = requests.get(target, allow_redirects=False, verify=True)
+        resp = requests.get(
+            target,
+            allow_redirects=False,
+            verify=True,
+            timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+        )
 
         # If the server returns an HTTP redirect (status code 3xx) the
         # server must also send the header "FIDO-AppID-Redirect-Authorized:


### PR DESCRIPTION
Hi! First and foremost, thanks for this utility :) 

This patch should solve the issue of occasional slowdowns on systems that use IPv6.
You can find more details about it in the commit message.

I put the new constants above the `from aws_google_auth ...` imports in `__init__.py` and not below (as would be more common) as there's currently a 'latent issue' of circular imports that manifests itself if we do otherways.
It could be solved by moving all the CLI-related code to a separate module and leaving only the constant declarations in the init.

You can find an example in https://github.com/glumia/aws-google-auth/tree/fix-circular-imports.
I avoided adding those changes to this pull request both because it would be out of scope and because I don't know if such an invasive change to package's structure is welcome.