### PR TITLE
Support SAML assertion caching for multiple profiles

### DIFF
--- a/aws_google_auth/configuration.py
+++ b/aws_google_auth/configuration.py
@@ -65,7 +65,7 @@ class Configuration(object):
 
     @property
     def saml_cache_file(self):
-        return self.credentials_file.replace('credentials', 'saml_cache_%s.xml' % self.idp_id)
+        return self.credentials_file.replace('credentials', 'saml_cache_%s_%s.xml' % (self.idp_id, self.profile))
 
     def ensure_config_files_exist(self):
         for file in [self.config_file, self.credentials_file]:


### PR DESCRIPTION
Currently the SAML assertion cache only works for a single profile. This
is because the logic only caters for a single cache file.

This PR allows response caching for multiple profiles, e.g.:

```
$ aws-google-auth --profile profile-a --keyring
Please visit the following URL to view your CAPTCHA: https://...
Captcha (case insensitive): ...
MFA token: ...
Assuming arn:aws:iam::111111111111:role/my-role
Credentials Expiration: 2022-03-29 22:43:51+11:00

$ aws-google-auth --profile profile-b --keyring
Please visit the following URL to view your CAPTCHA: https://...
Captcha (case insensitive): ...
MFA token: ...
Assuming arn:aws:iam::222222222222:role/my-role
Credentials Expiration: 2022-03-29 22:44:22+11:00

$ aws-google-auth --profile profile-a --keyring
Assuming arn:aws:iam::111111111111:role/my-role
Credentials Expiration: 2022-03-29 22:44:25+11:00

$ aws-google-auth --profile profile-b --keyring
Assuming arn:aws:iam::222222222222:role/my-role
Credentials Expiration: 2022-03-29 22:45:32+11:00
```