### PR TITLE
Add bg_response in request payload to passwd challenge

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -264,6 +264,10 @@ class Google:
         # Update the payload
         payload['Passwd'] = self.config.password
 
+        # Set bg_response in request payload to passwd challenge
+        if self.config.bg_response:
+            payload['bgresponse'] = self.config.bg_response
+
         # POST to Authenticate Password
         sess = self.post(passwd_challenge_url, data=payload)
 


### PR DESCRIPTION
This fix resolves the issue reported on https://github.com/cevoaustralia/aws-google-auth/issues/248

When adding the --bg-response parameter, the value is not passed on in the captcha validation request, which causes a validation error.

The error occurs because google blocks the request in new installations due to the default value that informs that there is no support for javascript "bg_response" with value "js_disabled".

It is necessary to pass the value as "bg_response" with value "js_enabled" to avoid the error in the google authentication flow.

But the error continues to occur in the captcha validation because this parameter was not passed on in the challenge response payload.

By adding "bg_response" with value "js_enabled" in the challenge submission, the authentication flow proceeds normally.

This error occurs in new installations of aws-google-auth, not being reproduced in installations that already existed, I can't explain why.