### PR TITLE
Fix lost bg_response option

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -284,6 +284,9 @@ class Google:
 
         self.check_extra_step(response_page)
 
+        if self.config.bg_response:
+            payload['bgresponse'] = self.config.bg_response
+
         # Process Google CAPTCHA verification request if present
         if cap is not None:
             self.session.headers['Referer'] = sess.url


### PR DESCRIPTION
#249
https://github.com/cevoaustralia/aws-google-auth/issues/248#issuecomment-1102707053

I too suffered from the same problem.

And I found that `js_enabled` can solve the NoneType problem.

So, if I use this command, it proceeds normally until to input captcha.

```
aws-google-auth \
  -u johngrib.lee@greenlabs.co.kr \
  -R ap-northeast-2 \
  -I C.... \
  -S 8.... \
  -p sinsun-backend \
  -d 3600 \
  --bg-response js_enabled
```

However, from then on, the NoneType error occurs again because js_enabled has lost.

![image](https://user-images.githubusercontent.com/1855714/164258078-02104713-4fcd-4c51-8d1c-2f7da62ca2e7.png)

So I tried to re-enter the js_enabled value in the payload, and the problem was solved.


