### PR TITLE
support python3.12

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -13,7 +13,10 @@ import sys
 import requests
 from PIL import Image
 from datetime import datetime
-from distutils.spawn import find_executable
+try:
+    from shutil import which as find_executable
+except ImportError:
+    from distutils.spawn import find_executable
 from bs4 import BeautifulSoup
 from requests import HTTPError
 from six import print_ as print


### PR DESCRIPTION
Python 3.12 has removed `distutils`: https://docs.python.org/3.12/whatsnew/3.12.html#removed
