### PR TITLE
Print the number-matching challenge code in device prompt flows

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -653,12 +653,55 @@ class Google:
     @staticmethod
     def check_prompt_code(response):
         """
-        Sometimes there is an additional numerical code on the response page that needs to be selected
-        on the prompt from a list of multiple choice. Print it if it's there.
+        Google Prompt sometimes requires number matching: the sign-in page
+        shows a number that the user must tap on their phone from a list of
+        multiple choice. A headless flow never renders that page, so the user
+        confirms blind unless we print the number.
+
+        Looks for the number in the known markup variants (newest first),
+        prints it if found, and returns it (None if the page has no number).
         """
-        num_code = response.find("div", {"jsname": "EKvSSd"})
+        # Current markup (observed 2026): <samp jsname="feLNVc">NN</samp>
+        num_code = response.find("samp", {"jsname": "feLNVc"})
         if num_code:
-            print("numerical code for prompt: {}".format(num_code.string))
+            code = num_code.get_text(strip=True)
+            if code.isdigit():
+                print("Tap this number on your phone: {}".format(code))
+                return code
+
+        # Same markup should the jsname churn: <samp> is ordinary HTML for
+        # computer output, so only accept a short (1-3 digits, like the
+        # codes Google uses and the text fallback below), purely numeric
+        # one; iterate in case the page carries others.
+        for num_code in response.find_all("samp"):
+            code = num_code.get_text(strip=True)
+            if code.isdigit() and len(code) <= 3:
+                print("Tap this number on your phone: {}".format(code))
+                return code
+
+        # Older markup: <div jsname="EKvSSd">NN</div>
+        num_code = response.find("div", {"jsname": "EKvSSd"})
+        if num_code and num_code.string:
+            code = num_code.string.strip()
+            if code.isdigit():
+                print("Tap this number on your phone: {}".format(code))
+                return code
+
+        # Fallback: the instruction text, e.g.
+        # "... then tap <b>NN</b> on your phone to verify it's you."
+        # Fail-closed even on a hostile page: the output is a fixed
+        # template plus at most three digits, so no page-controlled text
+        # can reach the terminal.
+        match = re.search(
+            r"tap\s+(\d{1,3})\s+on\s+your\s+phone",
+            response.get_text(" ", strip=True),
+            re.IGNORECASE)
+        if match:
+            code = match.group(1)
+            print("Tap this number on your phone: {}".format(code))
+            return code
+
+        return None
 
     def handle_totp(self, sess):
         response_page = BeautifulSoup(sess.text, 'html.parser')
@@ -693,6 +736,8 @@ class Google:
 
     def handle_dp(self, sess):
         response_page = BeautifulSoup(sess.text, 'html.parser')
+
+        self.check_prompt_code(response_page)
 
         input("Check your phone - after you have confirmed response press ENTER to continue.") or None
 

--- a/aws_google_auth/tests/google_prompt_number_challenge.html
+++ b/aws_google_auth/tests/google_prompt_number_challenge.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Google Accounts</title></head>
+<body>
+<section class="aN1Vld">
+  <div class="yOnVIb" jsname="MZArnb">
+    <span class="oN6qIb" jsname="y02b7d">
+      <figure class="BqYZt sN9fFf">
+        <samp class="IEIJ3d" jsname="feLNVc" translate="no">97</samp>
+      </figure>
+    </span>
+  </div>
+</section>
+<div class="yOnVIb" jsname="MZArnb">
+  <p class="vOZun" jsname="NhJ5Dd">Google sent a notification to your phone. Tap <strong>Yes</strong> on the notification, then tap <b>97</b> on your phone to verify it&#8217;s you.</p>
+</div>
+</body>
+</html>

--- a/aws_google_auth/tests/google_prompt_number_challenge_legacy.html
+++ b/aws_google_auth/tests/google_prompt_number_challenge_legacy.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Google Accounts</title></head>
+<body>
+<div class="vAV9bf" jsname="feLNVc">
+  <div jsname="EKvSSd">42</div>
+</div>
+<form id="challenge" action="/signin/challenge/az/5">
+  <input type="hidden" name="TL" value="EXAMPLE_TL_VALUE">
+</form>
+</body>
+</html>

--- a/aws_google_auth/tests/test_google.py
+++ b/aws_google_auth/tests/test_google.py
@@ -8,7 +8,9 @@ import base64
 
 from bs4 import BeautifulSoup
 
-from mock import Mock
+from mock import Mock, patch
+from six import StringIO
+
 from aws_google_auth import google
 
 
@@ -23,6 +25,77 @@ class TestGoogle(unittest.TestCase):
         response = BeautifulSoup(response, 'html.parser')
         with self.assertRaises(ValueError):
             google.Google.check_extra_step(response)
+
+    def test_check_prompt_code_current_markup(self):
+        # Number-matching challenge page as served in 2026:
+        # the number lives in a <samp jsname="feLNVc"> element.
+        # The print is the actual fix for #77/#23 (the user cannot see
+        # the rendered page), so pin it alongside the return value.
+        response = self.read_local_file('google_prompt_number_challenge.html')
+        response = BeautifulSoup(response, 'html.parser')
+        with patch('sys.stdout', new=StringIO()) as stdout:
+            self.assertEqual(google.Google.check_prompt_code(response), '97')
+        self.assertIn('97', stdout.getvalue())
+
+    def test_check_prompt_code_legacy_markup(self):
+        # Older challenge pages carried the number in <div jsname="EKvSSd">.
+        response = self.read_local_file(
+            'google_prompt_number_challenge_legacy.html')
+        response = BeautifulSoup(response, 'html.parser')
+        self.assertEqual(google.Google.check_prompt_code(response), '42')
+
+    def test_check_prompt_code_text_fallback(self):
+        # If the structured elements are absent, fall back to the
+        # instruction sentence.
+        html = (u'<html><body><p>Tap <b>Yes</b> on the notification, '
+                u'then tap <b>7</b> on your phone to verify.</p>'
+                u'</body></html>').encode('utf-8')
+        response = BeautifulSoup(html, 'html.parser')
+        self.assertEqual(google.Google.check_prompt_code(response), '7')
+
+    def test_check_prompt_code_samp_only(self):
+        # The <samp> branch must work on its own, with no instruction
+        # sentence (e.g. localized pages where the text fallback cannot
+        # match).
+        html = (u'<html><body><samp class="IEIJ3d" jsname="feLNVc">12'
+                u'</samp></body></html>').encode('utf-8')
+        response = BeautifulSoup(html, 'html.parser')
+        self.assertEqual(google.Google.check_prompt_code(response), '12')
+
+    def test_check_prompt_code_non_digit_samp(self):
+        # <samp> is ordinary HTML for computer output; non-numeric
+        # content must not be mistaken for a challenge number.
+        html = (u'<html><body><samp>Ctrl+C</samp><p>no challenge</p>'
+                u'</body></html>').encode('utf-8')
+        response = BeautifulSoup(html, 'html.parser')
+        self.assertIsNone(google.Google.check_prompt_code(response))
+
+    def test_check_prompt_code_skips_non_digit_samp(self):
+        # A numeric <samp> must still be found when a non-numeric one
+        # precedes it in document order, even without the jsname
+        # attribute (exercises the generic scan branch).
+        html = (u'<html><body><samp>Ctrl+C</samp>'
+                u'<samp>31</samp>'
+                u'</body></html>').encode('utf-8')
+        response = BeautifulSoup(html, 'html.parser')
+        self.assertEqual(google.Google.check_prompt_code(response), '31')
+
+    def test_check_prompt_code_non_digit_legacy_div(self):
+        # The legacy selector must also reject non-numeric content
+        # rather than print it as a challenge number.
+        html = (u'<html><body><div jsname="EKvSSd">N/A</div>'
+                u'</body></html>').encode('utf-8')
+        response = BeautifulSoup(html, 'html.parser')
+        self.assertIsNone(google.Google.check_prompt_code(response))
+
+    def test_check_prompt_code_absent(self):
+        # Pages without a number-matching challenge must return None
+        # and print nothing that could mislead the user.
+        response = self.read_local_file('google_error.html')
+        response = BeautifulSoup(response, 'html.parser')
+        with patch('sys.stdout', new=StringIO()) as stdout:
+            self.assertIsNone(google.Google.check_prompt_code(response))
+        self.assertEqual(stdout.getvalue(), '')
 
     def test_find_keyhandles(self):
         challenges_txt = "RFVNTVlDSEFMTEVOR0U="


### PR DESCRIPTION
Fixes #77
Fixes #23

## The problem

Google Prompt now uses **number matching**: the sign-in page displays a number, and the phone asks the user to tap the matching one from a list of three. Because `aws-google-auth` runs headless, that page is never rendered — the user is asked to pick a number they cannot see, and authentication fails (or succeeds only by a 1-in-3 guess).

## Root cause

Two things:

1. `check_prompt_code()` already existed for exactly this, but it only knows the legacy `<div jsname="EKvSSd">` markup. Current challenge pages carry the number in a `<samp jsname="feLNVc">` element, so the lookup silently finds nothing.
2. It was only wired into `handle_prompt()`. The device-prompt flow the challenge actually arrives on, `handle_dp()`, never called it.

## The change

`check_prompt_code()` now tries the known markup variants newest-first and returns the code (or `None`), which also makes it directly testable:

1. **Current markup** (observed 2026): `<samp jsname="feLNVc">NN</samp>`.
2. **Same markup if the obfuscated `jsname` churns**: any `<samp>` whose content is purely numeric and short (1-3 digits, matching the codes Google uses). `jsname` values are generated identifiers and rotate; the element type is much more stable.
3. **Legacy markup**: `<div jsname="EKvSSd">NN</div>` — kept so older tenants keep working.
4. **Text fallback**: the English instruction sentence ("...then tap *NN* on your phone..."), for when the structured elements move again.

Every layer validates that what it found is actually a short numeric code before printing, and the printed line is a fixed template plus at most three digits — no page-controlled text can reach the terminal. `handle_dp()` now calls it before blocking on the "press ENTER" confirmation.

Verified against a real, current Google challenge page: the `<samp>` branch matches and prints the correct number.

## Tests

Eight new tests in `test_google.py` cover the current markup (including the printed output, since the print *is* the fix), the legacy markup, the generic-`<samp>` scan (including skipping non-numeric `<samp>` content like `Ctrl+C`), the text fallback, non-numeric legacy divs, and pages with no challenge (returns `None`, prints nothing).

The two new HTML fixtures are **sanitized reconstructions** of real challenge pages — structure and class/jsname attributes are faithful, but all account data, tokens, and identifiers are replaced with placeholder values.

`pytest` and `flake8 --ignore E501,E722` both pass on the touched files.